### PR TITLE
ReduxStateInfra - Enable Redux state extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ const middlewares = [sagaMiddleware, routeMiddleware]
 // if (process.env.NODE_ENV === 'development') {
 //   middlewares.push(logger)
 // }
-const store = createStore(reducers(history), compose(applyMiddleware(...middlewares)))
+const store = createStore(
+  reducers(history),
+  compose(applyMiddleware(...middlewares), window.devToolsExtension && window.devToolsExtension()),
+)
 sagaMiddleware.run(sagas)
 
 ReactDOM.render(


### PR DESCRIPTION
Allow usage of Redux Dev Tools on chrome

### Changelog:
- Edited  /src/index.js

## Description:
_Eg; Fixed router bug_
- Enable the compatibility of frontend with Redux DevTools from Chrome extension.
- You can view the state of the store via the chrome extension now.
- Link to the chrome extension: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en
- I can explain more during tmr's meeting

## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
![image](https://user-images.githubusercontent.com/39340177/108068333-e7bc0480-709c-11eb-81b1-a1bb46b81ab5.png)
