### PR TITLE
A.1.7, A.1.8, A.1.10 User Profile - Add common ProfileCard component

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-resizable": "^1.10.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
+    "react-share": "^4.3.1",
     "react-sortable-tree": "^2.7.1",
     "react-sortablejs": "^2.0.11",
     "react-stickynode": "^2.1.1",

--- a/src/components/Profile/ProfileCard/index.js
+++ b/src/components/Profile/ProfileCard/index.js
@@ -1,60 +1,138 @@
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
-import { Modal } from 'antd'
+import { Descriptions, Form, Input, Modal } from 'antd'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ user }) => ({
   userData: {
-    firstName: user.firstName,
-    lastName: user.lastName,
-    username: user.username,
-    emailVerified: user.emailVerified,
-    email: user.email,
-    contactNumber: user.contactNumber,
+    firstName: user.firstName ? user.firstName : '',
+    lastName: user.lastName ? user.lastName : '',
+    username: user.username ? user.username : '',
+    emailVerified: user.emailVerified ? user.emailVerified : false,
+    email: user.email ? user.email : '',
+    contactNumber: user.contactNumber ? user.contactNumber : '',
     status: user.status,
+    userTypeEnum: user.userTypeEnum,
   },
 })
 
-const StudentProfileCard = ({ userData }) => {
+const onFinishFailed = errorInfo => {
+  console.log('Failed:', errorInfo)
+}
+
+const EditProfileForm = ({ userData }) => {
+  if (userData.userTypeEnum === 'STUDENT') {
+    return (
+      <Form
+        layout="vertical"
+        hideRequiredMark
+        onFinish={() => console.log('success')}
+        onFinishFailed={onFinishFailed}
+        initialValues={{
+          firstName: userData.firstName,
+          lastName: userData.lastName,
+          username: userData.username,
+          email: userData.email,
+          contactNumber: userData.contactNumber,
+        }}
+      >
+        <div className="row">
+          <div className="col-6">
+            <Form.Item name="username" label="Username">
+              <Input disabled />
+            </Form.Item>
+          </div>
+          <div className="col-6">
+            <Form.Item name="email" label="Email">
+              <Input disabled />
+            </Form.Item>
+          </div>
+          <div className="col-md-6">
+            <Form.Item
+              name="firstName"
+              label="First Name"
+              rules={[{ required: true, message: 'Please input your First Name' }]}
+            >
+              <Input />
+            </Form.Item>
+          </div>
+          <div className="col-md-6">
+            <Form.Item
+              name="lastName"
+              label="Last Name"
+              rules={[{ required: true, message: 'Please input your Last Name' }]}
+            >
+              <Input />
+            </Form.Item>
+          </div>
+          <div className="col-12">
+            <Form.Item name="contactNumber" label="Contact Number">
+              <Input />
+            </Form.Item>
+          </div>
+        </div>
+      </Form>
+    )
+  }
+  return <span>Bye</span>
+}
+
+const ProfileCard = ({ userData }) => {
   const [showEditProfile, setShowEditProfile] = useState(false)
 
   return (
-    <div className="d-flex flex-wrap flex-column align-items-center">
-      <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
-        <img src="../resources/images/avatars/5.jpg" alt="Mary Stanform" />
+    <div className="row justify-content-start">
+      <div className="col-auto">
+        <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
+          <img src="../resources/images/avatars/5.jpg" alt="Mary Stanform" />
+        </div>
       </div>
-      <div className="text-center">
+      <div className="col-auto">
         <div className="text-dark font-weight-bold font-size-18">{`${userData.firstName} ${userData.lastName}`}</div>
-        <div className="text-uppercase font-size-12 mb-3">Support team</div>
-        <button
-          type="button"
-          className={`btn btn-primary ${style.btnWithAddon}`}
-          onClick={() => setShowEditProfile(true)}
+        <div className="text-uppercase font-size-12 mb-3">{userData.userTypeEnum}</div>
+      </div>
+      <div className="col-12 text-left mt-2">
+        <Descriptions
+          title="Information"
+          bordered
+          size="small"
+          column={{ xxl: 1, xl: 1, lg: 1, md: 1, sm: 1, xs: 1 }}
+          extra={
+            <div>
+              <button
+                type="button"
+                className={`btn btn-primary ${style.btnWithAddon}`}
+                onClick={() => setShowEditProfile(true)}
+              >
+                <span className={`${style.btnAddon}`}>
+                  <i className={`${style.btnAddonIcon} fe fe-edit`} />
+                </span>
+                Edit
+              </button>
+              <button type="button" className="btn btn-outline-primary ml-2">
+                <span className={`${style.btnAddon}`}>
+                  <i className={`${style.btnAddonIcon} fe fe-share-2`} />
+                </span>
+              </button>
+            </div>
+          }
         >
-          <span className={`${style.btnAddon}`}>
-            <i className={`${style.btnAddonIcon} fe fe-edit`} />
-          </span>
-          Edit Profile
-        </button>
-        <button type="button" className="btn btn-outline-primary ml-2">
-          <span className={`${style.btnAddon}`}>
-            <i className={`${style.btnAddonIcon} fe fe-share-2`} />
-          </span>
-        </button>
+          <Descriptions.Item label="Username">{userData.username}</Descriptions.Item>
+          <Descriptions.Item label="Email">{userData.email}</Descriptions.Item>
+          <Descriptions.Item label="Contact Number">{userData.contactNumber}</Descriptions.Item>
+        </Descriptions>
       </div>
       <Modal
-        title="Basic Modal"
+        title="Edit Profile"
         visible={showEditProfile}
+        okText="Save"
         onOk={() => setShowEditProfile(false)}
         onCancel={() => setShowEditProfile(false)}
-        width="100%"
       >
-        <p>Some contents...</p>
-        <p>Some contents...</p>
-        <p>Some contents...</p>
+        <EditProfileForm userData={userData} />
       </Modal>
     </div>
   )
 }
 
-export default connect(mapStateToProps)(StudentProfileCard)
+export default connect(mapStateToProps)(ProfileCard)

--- a/src/components/Profile/ProfileCard/index.js
+++ b/src/components/Profile/ProfileCard/index.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
-import { Descriptions, Form, Input, Modal } from 'antd'
+import { Descriptions, Form, Input, Modal, Tabs, notification } from 'antd'
 import { FacebookShareButton, FacebookIcon, LinkedinShareButton, LinkedinIcon } from 'react-share'
 import style from './style.module.scss'
+
+const { TabPane } = Tabs
 
 const mapStateToProps = ({ user }) => ({
   userData: {
@@ -82,8 +84,81 @@ const EditProfileForm = ({ userData }) => {
   return <span>Bye</span>
 }
 
+const ChangePasswordForm = () => {
+  return (
+    <Form
+      layout="vertical"
+      hideRequiredMark
+      onFinish={() => console.log('success')}
+      onFinishFailed={onFinishFailed}
+    >
+      <div className="row">
+        <div className="col-12">
+          <Form.Item name="oldPassword" label="Old Password">
+            <Input />
+          </Form.Item>
+        </div>
+        <div className="col-6">
+          <Form.Item name="password" label="New Password">
+            <Input />
+          </Form.Item>
+        </div>
+        <div className="col-6">
+          <Form.Item name="confirmPassword" label="Confirm Password">
+            <Input />
+          </Form.Item>
+        </div>
+      </div>
+    </Form>
+  )
+}
+
+const DeleteAccountButton = () => {
+  return (
+    <div className="row">
+      <div className="col-12">
+        <button type="button" className="btn btn-danger mb-3">
+          Delete Account
+        </button>
+      </div>
+    </div>
+  )
+}
+
 const ProfileCard = ({ userData }) => {
-  const [showEditProfile, setShowEditProfile] = useState(false)
+  const [showEditInformation, setShowEditInformation] = useState(false)
+
+  const [tabKey, setTabKey] = useState('editProfile')
+
+  const changeTab = key => {
+    setTabKey(key)
+  }
+
+  const onFinish = () => {
+    notification.success({
+      message: 'Success',
+      description: 'Action successfully completed!',
+    })
+  }
+
+  const saveFormFooter = (
+    <div className="row justify-content-between">
+      <div className="col-auto">
+        <button
+          type="button"
+          onClick={() => setShowEditInformation(false)}
+          className="btn btn-outline-default"
+        >
+          Close
+        </button>
+      </div>
+      <div className="col-auto">
+        <button type="button" onClick={onFinish} className="btn btn-primary">
+          Save
+        </button>
+      </div>
+    </div>
+  )
 
   return (
     <div className="row justify-content-between">
@@ -115,7 +190,7 @@ const ProfileCard = ({ userData }) => {
               <button
                 type="button"
                 className={`btn btn-primary ${style.btnWithAddon}`}
-                onClick={() => setShowEditProfile(true)}
+                onClick={() => setShowEditInformation(true)}
               >
                 <span className={`${style.btnAddon}`}>
                   <i className={`${style.btnAddonIcon} fe fe-edit`} />
@@ -131,13 +206,26 @@ const ProfileCard = ({ userData }) => {
         </Descriptions>
       </div>
       <Modal
-        title="Edit Profile"
-        visible={showEditProfile}
-        okText="Save"
-        onOk={() => setShowEditProfile(false)}
-        onCancel={() => setShowEditProfile(false)}
+        title="Edit Information"
+        visible={showEditInformation}
+        cancelText="Close"
+        centered
+        okButtonProps={{ style: { display: 'none' } }}
+        onCancel={() => setShowEditInformation(false)}
+        bodyStyle={{ paddingTop: 0, paddingBottom: 0 }}
+        footer={
+          (tabKey === 'editProfile' && saveFormFooter) ||
+          (tabKey === 'changePassword' && saveFormFooter)
+        }
       >
-        <EditProfileForm userData={userData} />
+        <Tabs activeKey={tabKey} className="mr-auto kit-tabs-bold" onChange={changeTab}>
+          <TabPane tab="Edit Profile" key="editProfile" />
+          <TabPane tab="Change Password" key="changePassword" />
+          <TabPane tab="Delete Account" key="deleteAccount" />
+        </Tabs>
+        {tabKey === 'editProfile' && <EditProfileForm userData={userData} />}
+        {tabKey === 'changePassword' && <ChangePasswordForm />}
+        {tabKey === 'deleteAccount' && <DeleteAccountButton />}
       </Modal>
     </div>
   )

--- a/src/components/Profile/ProfileCard/index.js
+++ b/src/components/Profile/ProfileCard/index.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import { connect } from 'react-redux'
+import { Modal } from 'antd'
+import style from './style.module.scss'
+
+const mapStateToProps = ({ user }) => ({
+  userData: {
+    firstName: user.firstName,
+    lastName: user.lastName,
+    username: user.username,
+    emailVerified: user.emailVerified,
+    email: user.email,
+    contactNumber: user.contactNumber,
+    status: user.status,
+  },
+})
+
+const StudentProfileCard = ({ userData }) => {
+  const [showEditProfile, setShowEditProfile] = useState(false)
+
+  return (
+    <div className="d-flex flex-wrap flex-column align-items-center">
+      <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
+        <img src="../resources/images/avatars/5.jpg" alt="Mary Stanform" />
+      </div>
+      <div className="text-center">
+        <div className="text-dark font-weight-bold font-size-18">{`${userData.firstName} ${userData.lastName}`}</div>
+        <div className="text-uppercase font-size-12 mb-3">Support team</div>
+        <button
+          type="button"
+          className={`btn btn-primary ${style.btnWithAddon}`}
+          onClick={() => setShowEditProfile(true)}
+        >
+          <span className={`${style.btnAddon}`}>
+            <i className={`${style.btnAddonIcon} fe fe-edit`} />
+          </span>
+          Edit Profile
+        </button>
+        <button type="button" className="btn btn-outline-primary ml-2">
+          <span className={`${style.btnAddon}`}>
+            <i className={`${style.btnAddonIcon} fe fe-share-2`} />
+          </span>
+        </button>
+      </div>
+      <Modal
+        title="Basic Modal"
+        visible={showEditProfile}
+        onOk={() => setShowEditProfile(false)}
+        onCancel={() => setShowEditProfile(false)}
+        width="100%"
+      >
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+        <p>Some contents...</p>
+      </Modal>
+    </div>
+  )
+}
+
+export default connect(mapStateToProps)(StudentProfileCard)

--- a/src/components/Profile/ProfileCard/index.js
+++ b/src/components/Profile/ProfileCard/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { Descriptions, Form, Input, Modal } from 'antd'
+import { FacebookShareButton, FacebookIcon, LinkedinShareButton, LinkedinIcon } from 'react-share'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ user }) => ({
@@ -20,8 +21,12 @@ const onFinishFailed = errorInfo => {
   console.log('Failed:', errorInfo)
 }
 
+const shareUrl = 'https://github.com'
+let title = "I'm sharing my Digi Dojo profile with you!"
+
 const EditProfileForm = ({ userData }) => {
   if (userData.userTypeEnum === 'STUDENT') {
+    title = `${userData.firstName} is sharing his Digi Dojo profile with you!`
     return (
       <Form
         layout="vertical"
@@ -81,15 +86,23 @@ const ProfileCard = ({ userData }) => {
   const [showEditProfile, setShowEditProfile] = useState(false)
 
   return (
-    <div className="row justify-content-start">
+    <div className="row justify-content-between">
       <div className="col-auto">
         <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
           <img src="../resources/images/avatars/5.jpg" alt="Mary Stanform" />
         </div>
       </div>
-      <div className="col-auto">
+      <div className="col">
         <div className="text-dark font-weight-bold font-size-18">{`${userData.firstName} ${userData.lastName}`}</div>
         <div className="text-uppercase font-size-12 mb-3">{userData.userTypeEnum}</div>
+      </div>
+      <div className="col-auto">
+        <FacebookShareButton url={shareUrl} quote={title}>
+          <FacebookIcon size={32} round />
+        </FacebookShareButton>
+        <LinkedinShareButton url={shareUrl} className="ml-2">
+          <LinkedinIcon size={32} round />
+        </LinkedinShareButton>
       </div>
       <div className="col-12 text-left mt-2">
         <Descriptions
@@ -108,11 +121,6 @@ const ProfileCard = ({ userData }) => {
                   <i className={`${style.btnAddonIcon} fe fe-edit`} />
                 </span>
                 Edit
-              </button>
-              <button type="button" className="btn btn-outline-primary ml-2">
-                <span className={`${style.btnAddon}`}>
-                  <i className={`${style.btnAddonIcon} fe fe-share-2`} />
-                </span>
               </button>
             </div>
           }

--- a/src/components/Profile/ProfileCard/style.module.scss
+++ b/src/components/Profile/ProfileCard/style.module.scss
@@ -1,0 +1,26 @@
+@import 'components/mixins.scss';
+
+.btnWithAddon {
+  overflow: hidden;
+  position: relative;
+  padding-left: rem(50) !important;
+  border: none;
+
+  .btnAddon {
+    position: absolute;
+    z-index: 1;
+    top: -1px;
+    left: -1px;
+    bottom: -1px;
+    background-color: rgba($white, 0.2);
+    width: rem(40);
+  }
+
+  .btnAddonIcon {
+    font-size: rem(16);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/src/pages/student/profile/index.js
+++ b/src/pages/student/profile/index.js
@@ -1,12 +1,9 @@
 import React, { useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Tabs, Input, Button, Upload, Form } from 'antd'
-import General1 from 'components/kit/widgets/General/1'
-import General10v1 from 'components/kit/widgets/General/10v1'
-import General12v1 from 'components/kit/widgets/General/12v1'
+import ProfileCard from 'components/Profile/ProfileCard'
 import General14 from 'components/kit/widgets/General/14'
 import General15 from 'components/kit/widgets/General/15'
-import List19 from 'components/kit/widgets/Lists/19'
 
 const { TabPane } = Tabs
 
@@ -24,20 +21,7 @@ const StudentProfile = () => {
         <div className="col-xl-4 col-lg-12">
           <div className="card">
             <div className="card-body">
-              <General10v1 />
-            </div>
-          </div>
-          <div className="card text-white bg-primary">
-            <General12v1 />
-          </div>
-          <div className="card">
-            <div className="card-body">
-              <General1 />
-            </div>
-          </div>
-          <div className="card">
-            <div className="card-body">
-              <List19 />
+              <ProfileCard />
             </div>
           </div>
         </div>

--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -115,6 +115,7 @@ export function* LOAD_CURRENT_ACCOUNT() {
       email,
       contactNumber,
       status,
+      userTypeEnum,
     } = response
     yield put({
       type: 'user/SET_STATE',
@@ -132,6 +133,7 @@ export function* LOAD_CURRENT_ACCOUNT() {
         email,
         contactNumber,
         status,
+        userTypeEnum,
       },
     })
   }

--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -103,16 +103,35 @@ export function* LOAD_CURRENT_ACCOUNT() {
   const { authProvider } = yield select(state => state.settings)
   const response = yield call(mapAuthProviders[authProvider].currentAccount)
   if (response) {
-    const { id, email, name, avatar, role } = response
+    const {
+      id,
+      name,
+      avatar,
+      role,
+      username,
+      firstName,
+      lastName,
+      emailVerified,
+      email,
+      contactNumber,
+      status,
+    } = response
     yield put({
       type: 'user/SET_STATE',
       payload: {
         id,
         name,
-        email,
         avatar,
         role,
         authorized: true,
+        // Add attributes from backend
+        username,
+        firstName,
+        lastName,
+        emailVerified,
+        email,
+        contactNumber,
+        status,
       },
     })
   }

--- a/src/services/axios/fakeApi/auth/index.js
+++ b/src/services/axios/fakeApi/auth/index.js
@@ -12,11 +12,18 @@ const users = [
   },
   {
     id: 2,
-    email: 'student',
-    password: 'demo123',
     name: 'Student',
     avatar: '',
     role: 'student',
+    // Add database columns from backend
+    username: 'student',
+    password: 'demo123',
+    firstName: 'Lawrence',
+    lastName: 'Lim',
+    emailVerified: true,
+    email: 'student',
+    contactNumber: 90001234,
+    status: 'ACTIVE',
   },
   {
     id: 3,

--- a/src/services/axios/fakeApi/auth/index.js
+++ b/src/services/axios/fakeApi/auth/index.js
@@ -24,6 +24,7 @@ const users = [
     email: 'student',
     contactNumber: 90001234,
     status: 'ACTIVE',
+    userTypeEnum: 'STUDENT',
   },
   {
     id: 3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4433,7 +4433,7 @@ dayjs@^1.8.30:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.35.tgz#67118378f15d31623f3ee2992f5244b887606888"
   integrity sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -7864,6 +7864,13 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
+  dependencies:
+    debug "^2.1.3"
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
@@ -11561,6 +11568,14 @@ react-scripts@3.4.1:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-share@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-4.3.1.tgz#2eac80bc5e3f1c6d83c7315342db1fd2f21009d3"
+  integrity sha512-ikh0y8NKxhU7dQBXh1Jccd1ANLb9WNYaSonln33yLyNYo2HTBRp9D6HkTsFlgX/2J9GPsGLqhzzpDNiVKx3WVA==
+  dependencies:
+    classnames "^2.2.5"
+    jsonp "^0.2.1"
 
 react-side-effect@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Feature

Use Case: A.1.7 View User Profile, A.1.8 Edit User Profile, A.1.10 Share User Profile
Feature ID : 3
Feature: Sensei/Student Profile
Figma link for wireframe: N.A. (No wireframe available)

# Changelog:
Add temporary sample data in mock axios API response for Student based on backend database table attributes
Add modular ProfileCard with support for different userTypes; only 'STUDENT' is supported for now
Add react-share third party library for sharing URL to facebook (to be changed when we have a public facing profile page for students)
TODO: Modify modal to be more UX-friendly, leaving it as this for functional purpose as I need to move on to doing other components for now

# Merge/Review Order

**Please run 'yarn install' to update your node-modules with the react-share library.**

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
<img width="351" alt="image" src="https://user-images.githubusercontent.com/43084055/108313313-1815b700-71f3-11eb-9637-04e63f92eec6.png">
<img width="309" alt="image" src="https://user-images.githubusercontent.com/43084055/108313400-3c719380-71f3-11eb-8b06-1de7513f4162.png">
<img width="403" alt="image" src="https://user-images.githubusercontent.com/43084055/108313501-662aba80-71f3-11eb-8f58-3d1460320e0f.png">
<img width="913" alt="image" src="https://user-images.githubusercontent.com/43084055/108313526-6e82f580-71f3-11eb-951e-b618687b422d.png">

<img width="726" alt="image" src="https://user-images.githubusercontent.com/43084055/108313326-1e0b9800-71f3-11eb-94ca-b64b9e4df66c.png">
<img width="743" alt="image" src="https://user-images.githubusercontent.com/43084055/108313333-219f1f00-71f3-11eb-91c2-657fa39799e9.png">
<img width="721" alt="image" src="https://user-images.githubusercontent.com/43084055/108313347-2532a600-71f3-11eb-8456-1a848904e9e9.png">
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/43084055/108313365-2bc11d80-71f3-11eb-997b-d253cf534a36.png">
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/43084055/108313378-324f9500-71f3-11eb-9a2a-7678c790b591.png">
