### PR TITLE
Fix menu colour, login page double fade bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-chartjs-2": "^2.9.0",
     "react-dom": "^16.13.1",
     "react-draft-wysiwyg": "^1.14.5",
+    "react-fade-in": "^2.0.1",
     "react-helmet": "^6.0.0",
     "react-highlight-words": "^0.16.0",
     "react-intl": "^4.5.1",

--- a/src/components/cleanui/system/Auth/Login/index.js
+++ b/src/components/cleanui/system/Auth/Login/index.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Input, Button, Form } from 'antd'
 import { Link, useLocation, Redirect } from 'react-router-dom'
-import Fade from 'reactstrap/lib/Fade'
+import FadeIn from 'react-fade-in'
 import LogoWithDescription from 'components/Public/Logo/LogoWithDescription'
 import { USER_TYPE_ENUM, USER_TYPE_STRING } from 'constants/constants'
 
@@ -40,41 +40,43 @@ const Login = () => {
   }
 
   const SelectUserType = (
-    <div
-      style={{
-        display: currentUserType === '' ? 'block' : 'none',
-      }}
-    >
-      <div className="row mb-3 align-items-center">
-        <div className="col-12 text-center">{LogoWithDescription}</div>
-      </div>
-      <div className="row justify-content-center">
-        <div className="col-12 col-md-4">
-          <Button
-            block
-            type="primary"
-            size="large"
-            onClick={() => setCurrentUserType(USER_TYPE_ENUM.SENSEI)}
-            className="text-center"
-          >
-            <i className="fa fa-graduation-cap" />
-            &nbsp;&nbsp;Login as a {USER_TYPE_STRING.SENSEI}
-          </Button>
+    <FadeIn key="2">
+      <div
+        style={{
+          display: currentUserType === '' ? 'block' : 'none',
+        }}
+      >
+        <div className="row mb-3 align-items-center">
+          <div className="col-12 text-center">{LogoWithDescription}</div>
         </div>
-        <div className="col-12 col-md-4 mt-3 mt-md-0">
-          <Button
-            block
-            type="primary"
-            size="large"
-            onClick={() => setCurrentUserType(USER_TYPE_ENUM.STUDENT)}
-            className="text-center"
-          >
-            <i className="fa fa-user" />
-            &nbsp;&nbsp;Login as a {USER_TYPE_STRING.STUDENT}
-          </Button>
+        <div className="row justify-content-center">
+          <div className="col-12 col-md-4">
+            <Button
+              block
+              type="primary"
+              size="large"
+              onClick={() => setCurrentUserType(USER_TYPE_ENUM.SENSEI)}
+              className="text-center"
+            >
+              <i className="fa fa-graduation-cap" />
+              &nbsp;&nbsp;Login as a {USER_TYPE_STRING.SENSEI}
+            </Button>
+          </div>
+          <div className="col-12 col-md-4 mt-3 mt-md-0">
+            <Button
+              block
+              type="primary"
+              size="large"
+              onClick={() => setCurrentUserType(USER_TYPE_ENUM.STUDENT)}
+              className="text-center"
+            >
+              <i className="fa fa-user" />
+              &nbsp;&nbsp;Login as a {USER_TYPE_STRING.STUDENT}
+            </Button>
+          </div>
         </div>
       </div>
-    </div>
+    </FadeIn>
   )
 
   const SwitchUserTypeButton = () => {
@@ -96,53 +98,51 @@ const Login = () => {
 
   const LoginForm = () => {
     return (
-      <Fade>
-        <div className="card">
-          <div className="card-body">
-            <div className="text-dark text-center font-size-24 mb-3">
-              <strong>
-                {getPortalName()}
-                &nbsp;Portal
-              </strong>
-            </div>
-            <Form
-              layout="vertical"
-              hideRequiredMark
-              onFinish={onFinish}
-              onFinishFailed={onFinishFailed}
-              className="mb-4"
-              initialValues={{ email: currentUserType.toLowerCase(), password: 'demo123' }}
+      <div className="card">
+        <div className="card-body">
+          <div className="text-dark text-center font-size-24 mb-3">
+            <strong>
+              {getPortalName()}
+              &nbsp;Portal
+            </strong>
+          </div>
+          <Form
+            layout="vertical"
+            hideRequiredMark
+            onFinish={onFinish}
+            onFinishFailed={onFinishFailed}
+            className="mb-4"
+            initialValues={{ email: currentUserType.toLowerCase(), password: 'demo123' }}
+          >
+            <Form.Item
+              name="email"
+              rules={[{ required: true, message: 'Please input your e-mail address' }]}
             >
-              <Form.Item
-                name="email"
-                rules={[{ required: true, message: 'Please input your e-mail address' }]}
-              >
-                <Input size="large" placeholder="Email" />
-              </Form.Item>
-              <Form.Item
-                name="password"
-                rules={[{ required: true, message: 'Please input your password' }]}
-              >
-                <Input size="large" type="password" placeholder="Password" />
-              </Form.Item>
-              <Button
-                type="primary"
-                size="large"
-                className="text-center w-100"
-                htmlType="submit"
-                loading={user.loading}
-              >
-                <strong>Login</strong>
-              </Button>
-            </Form>
-            <div className="text-center">
-              <Link to="/auth/forgot-password" className="kit__utils__link font-size-16">
-                Forgot Password?
-              </Link>
-            </div>
+              <Input size="large" placeholder="Email" />
+            </Form.Item>
+            <Form.Item
+              name="password"
+              rules={[{ required: true, message: 'Please input your password' }]}
+            >
+              <Input size="large" type="password" placeholder="Password" />
+            </Form.Item>
+            <Button
+              type="primary"
+              size="large"
+              className="text-center w-100"
+              htmlType="submit"
+              loading={user.loading}
+            >
+              <strong>Login</strong>
+            </Button>
+          </Form>
+          <div className="text-center">
+            <Link to="/auth/forgot-password" className="kit__utils__link font-size-16">
+              Forgot Password?
+            </Link>
           </div>
         </div>
-      </Fade>
+      </div>
     )
   }
 
@@ -170,16 +170,18 @@ const Login = () => {
   }
 
   const CommonLoginComponent = (
-    <div className="container">
-      {SelectUserType}
-      <div className="row justify-content-between align-items-center">
-        <div className="col-12 col-md-6 text-center">{LogoWithDescription}</div>
-        <div className="col-12 col-md-6 mt-3 mt-md-0">
-          <LoginForm />
+    <FadeIn key="1">
+      <div className="container">
+        {SelectUserType}
+        <div className="row justify-content-between align-items-center">
+          <div className="col-12 col-md-6 text-center">{LogoWithDescription}</div>
+          <div className="col-12 col-md-6 mt-3 mt-md-0">
+            <LoginForm />
+          </div>
         </div>
+        <UserAdditionalActions />
       </div>
-      <UserAdditionalActions />
-    </div>
+    </FadeIn>
   )
 
   if (currentUserType !== '') {

--- a/src/redux/settings/reducers.js
+++ b/src/redux/settings/reducers.js
@@ -22,7 +22,7 @@ const initialState = {
     isMenuCollapsed: false,
     menuLayoutType: 'left', // left, top, nomenu
     routerAnimation: 'slide-fadein-up', // none, slide-fadein-up, slide-fadein-right, fadein, zoom-fadein
-    menuColor: 'white', // white, dark, gray
+    menuColor: 'gray', // white, dark, gray
     theme: 'default', // default, dark
     authPagesColor: 'white', // white, gray, image
     primaryColor: '#4b7cf3',

--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -104,12 +104,6 @@ export function* REGISTER({ payload }) {
 
 export function* LOAD_CURRENT_ACCOUNT() {
   yield put({
-    type: 'user/SET_STATE',
-    payload: {
-      loading: true,
-    },
-  })
-  yield put({
     type: 'menu/GET_DATA',
   })
   const { authProvider } = yield select(state => state.settings)
@@ -149,12 +143,6 @@ export function* LOAD_CURRENT_ACCOUNT() {
       },
     })
   }
-  yield put({
-    type: 'user/SET_STATE',
-    payload: {
-      loading: false,
-    },
-  })
 }
 
 export function* LOGOUT() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11378,6 +11378,11 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-fade-in@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-fade-in/-/react-fade-in-2.0.1.tgz#b4bcd7dac63d6857ebcd68facbff2f5f9616278f"
+  integrity sha512-oqS/WT4znaXEHmL+yo0IDUDY7uC9K4RP35j1SdRUEBspR09B2iIC0i8oJ28tPOr6Ez/L2aktF9p89j+DbsTVNw==
+
 react-fast-compare@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"


### PR DESCRIPTION
# Feature

Use Case: N.A.
Feature ID: N.A.
Feature: N.A.
Figma link for wireframe: N.A.

# Changelog:
add react-fade-in library for fade animation, update top menu bar to gray colour
this fixes the fade issue when clicking the login button as the button with loading state forces the elements to reload, triggering multiple fades.
_react-fade-in library is newer than reactstrap's Fade and allows for re-rendering when props change_

**please run yarn install to update packages**

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
