### PR TITLE
Fix admin object not being set correctly when page is refreshed

### DIFF
--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -103,12 +103,12 @@ export function* REGISTER({ payload }) {
 export function* LOAD_CURRENT_ACCOUNT() {
   const user = yield call(jwt.getLocalUserData)
   if (user) {
-    const currentUser = createUserObj(
-      user,
-      user.authorized,
-      user.loading,
-      user.requiresProfileUpdate,
-    )
+    let currentUser = resetUser
+    if (user.userType === USER_TYPE_ENUM.ADMIN) {
+      currentUser = createAdminObj(user, user.authorized, user.loading)
+    } else {
+      currentUser = createUserObj(user, user.authorized, user.loading, user.requiresProfileUpdate)
+    }
     yield put({
       type: 'user/SET_STATE',
       payload: currentUser,


### PR DESCRIPTION
# Changelog:
Fix issue where admin object is returned as user object instead from localStorage upon refresh

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
