### PR TITLE
fix logo disappearing, default tab switch to security

### DIFF
--- a/src/components/Public/PublicMenuBar/MenuLeft/index.js
+++ b/src/components/Public/PublicMenuBar/MenuLeft/index.js
@@ -191,7 +191,7 @@ const MenuLeft = ({
       >
         <div className={style.logoContainer}>
           <div className={style.logo}>
-            <img src="../resources/images/logo.svg" className="mr-2" alt="Clean UI" />
+            <img src="/resources/images/logo.svg" className="mr-2" alt="Clean UI" />
             <div className={style.name}>{logo}</div>
             {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
           </div>

--- a/src/components/Public/PublicMenuBar/MenuTop/index.js
+++ b/src/components/Public/PublicMenuBar/MenuTop/index.js
@@ -133,7 +133,7 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="../resources/images/logo.svg" className="mr-2" alt="Clean UI" />
+          <img src="/resources/images/logo.svg" className="mr-2" alt="Clean UI" />
           <div className={style.name}>{logo}</div>
         </div>
       </div>

--- a/src/components/cleanui/layout/Menu/MenuTop/index.js
+++ b/src/components/cleanui/layout/Menu/MenuTop/index.js
@@ -131,9 +131,8 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="../resources/images/logo.svg" className="mr-2" alt="Clean UI" />
+          <img src="/resources/images/logo.svg" className="mr-2" alt="Clean UI" />
           <div className={style.name}>{logo}</div>
-          {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
         </div>
       </div>
       <div className={style.navigation}>

--- a/src/layouts/Auth/index.js
+++ b/src/layouts/Auth/index.js
@@ -46,7 +46,7 @@ const AuthLayout = ({
           >
             <div className={style.logoContainer}>
               <a href="/" className={style.logo}>
-                <img src="../resources/images/logo.svg" className="mr-2" alt="Clean UI" />
+                <img src="/resources/images/logo.svg" className="mr-2" alt="Clean UI" />
                 <div className={style.name}>{logo}</div>
                 {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
               </a>

--- a/src/pages/sensei/settings/index.js
+++ b/src/pages/sensei/settings/index.js
@@ -16,7 +16,7 @@ const SenseiSettings = () => {
   let isEmailNotifOn = !!user.emailNotification
   let currentMessagePriv = user.chatPrivacy
 
-  const [activeTab, setActiveTab] = useState('privacy')
+  const [activeTab, setActiveTab] = useState('security')
   const [isConfirmDelete, setIsConfirmDelete] = useState(false)
   const [togglePrivacy, setTogglePrivacy] = useState(isPrivateUser)
   const [toggleEmailNotif, setToggleEmailNotif] = useState(isEmailNotifOn)

--- a/src/pages/student/settings/index.js
+++ b/src/pages/student/settings/index.js
@@ -16,7 +16,7 @@ const StudentSettings = () => {
   let isEmailNotifOn = !!user.emailNotification
   let currentMessagePriv = user.chatPrivacy
 
-  const [activeTab, setActiveTab] = useState('privacy')
+  const [activeTab, setActiveTab] = useState('security')
   const [isConfirmDelete, setIsConfirmDelete] = useState(false)
   const [togglePrivacy, setTogglePrivacy] = useState(isPrivateUser)
   const [toggleEmailNotif, setToggleEmailNotif] = useState(isEmailNotifOn)


### PR DESCRIPTION
# Changelog:
fix links to logo image
default tab for account settings is security instead of privacy

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
