### PR TITLE
D.1.10, 11, 12 facebook and url share for mentorship listing in student access

### DIFF
--- a/src/components/Mentorship/ListingDetails/MentorshipProfileHeader.js
+++ b/src/components/Mentorship/ListingDetails/MentorshipProfileHeader.js
@@ -1,12 +1,22 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import { Button } from 'antd'
+import { Button, Modal, Typography } from 'antd'
 
-import { CheckSquareOutlined, ArrowLeftOutlined } from '@ant-design/icons'
+import { CheckSquareOutlined, ArrowLeftOutlined, QrcodeOutlined } from '@ant-design/icons'
+import QRCode from 'react-qr-code'
+import { FacebookIcon, FacebookShareButton } from 'react-share'
+import { useSelector } from 'react-redux'
 
 const MentorshipProfileHeader = () => {
   const { id } = useParams()
   const history = useHistory()
+  const user = useSelector(state => state.user)
+  const [showQRCode, setShowQRCode] = useState(false)
+
+  const { Paragraph } = Typography
+
+  const shareUrl = `http://digi.dojo/mentorship/view/${id}`
+  const title = `${user.firstName} is sharing a Digi Dojo mentorship listing with you!`
 
   const onBack = e => {
     e.preventDefault()
@@ -20,7 +30,7 @@ const MentorshipProfileHeader = () => {
   }
 
   return (
-    <div className="row justify-content-between">
+    <div className="row justify-content-between ">
       <div className="col-auto">
         <Button
           type="primary"
@@ -32,7 +42,19 @@ const MentorshipProfileHeader = () => {
           Back
         </Button>
       </div>
-      <div className="col-auto">
+      <div className="col-auto d-flex justify-content-center">
+        <FacebookShareButton className="mr-4" url={shareUrl} quote={title} hashtag="DigiDojo">
+          <FacebookIcon size={38} round />
+        </FacebookShareButton>
+
+        <Button
+          className="mr-4"
+          type="primary"
+          shape="round"
+          icon={<QrcodeOutlined />}
+          size="large"
+          onClick={() => setShowQRCode(true)}
+        />
         <Button
           type="primary"
           size="large"
@@ -43,6 +65,29 @@ const MentorshipProfileHeader = () => {
           Apply for Mentorship
         </Button>
       </div>
+      <Modal
+        title="View QR"
+        visible={showQRCode}
+        cancelText="Close"
+        centered
+        okButtonProps={{ style: { display: 'none' } }}
+        onCancel={() => setShowQRCode(false)}
+      >
+        <div className="row mt-3">
+          <div className="col-12 text-center">
+            <QRCode value={`http://localhost:3000/mentorship/view/${id}`} />
+            <div className="mt-3">
+              <Paragraph
+                copyable={{
+                  text: `http://localhost:3000/mentorship/view/${id}`,
+                }}
+              >
+                Share Link
+              </Paragraph>
+            </div>
+          </div>
+        </div>
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
# Feature

Use Case: D.1.10 Share a Mentorship Listing as URL,  D.1.11 Share a Mentorship Listing as QR code, D.1.12 Share a Mentorship Listing as Facebook post (*new*, will be adding to sheets)
Feature ID : 10
Feature: Social Networking (but highly linked to Mentorship listing page which i was modifying)

**Note**: from 14/3's discussion, we wanted to revamp this page. will be revamping this in a later PR

# Changelog:
- add facebook share button
- add QR code button (reused from profile)


## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
<img width="1280" alt="Screenshot 2021-03-15 at 10 45 28 AM" src="https://user-images.githubusercontent.com/41737751/111098886-5ba7da80-857f-11eb-8b0f-fad276897a2d.png">
