### PR TITLE
Fix toggle message privilege description change bug

### DIFF
--- a/src/components/Settings/AccountSettings/index.js
+++ b/src/components/Settings/AccountSettings/index.js
@@ -19,6 +19,7 @@ const AccountSettings = () => {
   const [activeTab, setActiveTab] = useState('security')
   const [isConfirmDelete, setIsConfirmDelete] = useState(false)
   const [togglePrivacy, setTogglePrivacy] = useState(isPrivateUser)
+  const [toggleMessagePrivilege, setToggleMessagePrivilege] = useState(currentMessagePriv)
   const [toggleEmailNotif, setToggleEmailNotif] = useState(isEmailNotifOn)
 
   const changeActiveTab = tabKey => {
@@ -84,6 +85,7 @@ const AccountSettings = () => {
   }
 
   const onChangeMsgPrivileges = value => {
+    setToggleMessagePrivilege(value)
     currentMessagePriv = value
     const payload = {
       accountId: user.accountId,
@@ -106,6 +108,18 @@ const AccountSettings = () => {
         profile and follow you without approval.
       </small>
     )
+  }
+
+  const MessagePrivilegeToggleMsg = () => {
+    if (toggleMessagePrivilege === PRIVACY_PERMISSIONS_ENUM.NONE) {
+      return <small>You can receive messages from no one.</small>
+    }
+
+    if (toggleMessagePrivilege === PRIVACY_PERMISSIONS_ENUM.FOLLOWING_ONLY) {
+      return <small>You can receive messages only from those who you follow.</small>
+    }
+
+    return <small>You can receive messages from everyone.</small>
   }
 
   const HasEmailNotifMsg = () => {
@@ -254,7 +268,7 @@ const AccountSettings = () => {
                     <Option value={PRIVACY_PERMISSIONS_ENUM.NONE}>No one</Option>
                   </Select>
                   <div className="mt-2">
-                    <small>You can receive messages from everyone.</small>
+                    <MessagePrivilegeToggleMsg />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
# Changelog:
- add new state for toogleMessagePrivilege and dynamic component `MessagePrivilegeToggleMsg`

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
<img width="700" alt="Screenshot 2021-03-16 at 12 59 44 AM" src="https://user-images.githubusercontent.com/41737751/111191605-33f25a00-85f3-11eb-817e-b9c8244ab689.png">
<img width="698" alt="Screenshot 2021-03-16 at 12 59 34 AM" src="https://user-images.githubusercontent.com/41737751/111191617-36ed4a80-85f3-11eb-8ba4-ee1508caa346.png">
<img width="718" alt="Screenshot 2021-03-16 at 12 59 28 AM" src="https://user-images.githubusercontent.com/41737751/111191620-3785e100-85f3-11eb-88f3-b05d54857cf3.png">
