### PR TITLE
H.2.3,4 view wallet and withdraw functionality (sensei)

### DIFF
--- a/src/constants/notifications/index.js
+++ b/src/constants/notifications/index.js
@@ -35,6 +35,9 @@ export const ANNOUNCEMENT_EDIT_ERR = 'There was an error updating your announcem
 export const ANNOUNCEMENT_DEL_SUCCESS = 'Your announcement was successfully deleted.'
 export const ANNOUNCEMENT_DEL_ERR = 'There was an error deleting your announcement.'
 
+export const WITHDRAWAL_REQUEST_SUCCESS = 'Your withdrawal request was successfully sent.'
+export const WITHDRAWAL_REQUEST_ERR = 'There was an error sending your withdrawal request.'
+
 export const SUCCESS = 'Success'
 export const ERROR = 'Error'
 export const WARNING = 'Warning'

--- a/src/pages/sensei/wallet/index.js
+++ b/src/pages/sensei/wallet/index.js
@@ -1,14 +1,37 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button, Popconfirm, Tooltip } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
+import { viewWallet, requestWithdrawal } from 'services/wallet'
+import { useSelector } from 'react-redux'
+import { filter, isEmpty, isNil } from 'lodash'
+import {
+  WITHDRAWAL_REQUEST_ERR,
+  WITHDRAWAL_REQUEST_SUCCESS,
+  SUCCESS,
+  ERROR,
+} from 'constants/notifications'
+import { showNotification } from 'components/utils'
 
 const SenseiWallet = () => {
+  const user = useSelector(state => state.user)
   const [isConfirmWithdraw, setIsConfirmWithdraw] = useState(false)
+  const [wallet, setWallet] = useState([])
 
-  // to get from backend eventually
-  const confirmedAmount = 513
-  const pendingAmount = 23.4
-  const totalAmount = 772.8
+  const { walletId } = user
+  const { confirmedAmount, pendingAmount, totalEarned, BillingsReceived } = wallet
+
+  const isWithdrawable = confirmedAmount > 0
+  const isExistingWithdrawalRequest = !isEmpty(
+    filter(BillingsReceived, ['status', 'PENDING_WITHDRAWAL']),
+  )
+
+  useEffect(() => {
+    const getWalletEffect = async () => {
+      const result = await viewWallet(walletId)
+      setWallet(result.wallet)
+    }
+    getWalletEffect()
+  }, [walletId])
 
   const showPopconfirm = () => {
     setIsConfirmWithdraw(true)
@@ -16,6 +39,18 @@ const SenseiWallet = () => {
 
   const handleCancel = () => {
     setIsConfirmWithdraw(false)
+  }
+
+  const handleWithdrawConfirmedAmount = async () => {
+    setIsConfirmWithdraw(false)
+    const result = await requestWithdrawal(walletId)
+    if (result && !isNil(result.success)) {
+      if (result.success) {
+        showNotification('success', SUCCESS, WITHDRAWAL_REQUEST_SUCCESS)
+      }
+    } else {
+      showNotification('error', ERROR, WITHDRAWAL_REQUEST_ERR)
+    }
   }
 
   const WalletHeader = () => {
@@ -28,23 +63,31 @@ const SenseiWallet = () => {
           <Tooltip title="Your revenue earned since registeration">
             <InfoCircleOutlined className="mx-2" />
           </Tooltip>
-          <span>Total Amount Earned: S${totalAmount.toFixed(2)}</span>
+          <span>
+            Total Amount Earned: S${!isNil(totalEarned) ? parseFloat(totalEarned).toFixed(2) : '-'}
+          </span>
         </div>
       </div>
     )
   }
 
-  const showWithdrawButton = () => {
+  const WithdrawButton = () => {
     return (
       <Popconfirm
         title="Do you wish to withdraw your entire Confirmed Amount? This cannot be reversed."
         visible={isConfirmWithdraw}
-        onConfirm={() => {}} // to add when link with backend
+        onConfirm={() => handleWithdrawConfirmedAmount()}
         okText="Withdraw"
         okType="primary"
         onCancel={handleCancel}
       >
-        <Button block ghost type="primary" onClick={showPopconfirm}>
+        <Button
+          block
+          ghost
+          disabled={!isWithdrawable || isExistingWithdrawalRequest}
+          type="primary"
+          onClick={showPopconfirm}
+        >
           Withdraw
         </Button>
       </Popconfirm>
@@ -52,6 +95,7 @@ const SenseiWallet = () => {
   }
 
   const ConfirmedAmountContent = () => {
+    const textStyle = isExistingWithdrawalRequest ? 'text-muted' : 'text-dark'
     return (
       <div className="row align-items-center justify-content-between mb-4">
         <div className="col-auto">
@@ -61,7 +105,9 @@ const SenseiWallet = () => {
           <span className="text-dark h3">Confirmed Amount</span>
         </div>
         <div className="col-auto">
-          <span className="text-dark text-center h3">S${confirmedAmount.toFixed(2)}</span>
+          <span className={`${textStyle} text-center h3`}>
+            S${!isNil(confirmedAmount) ? parseFloat(confirmedAmount).toFixed(2) : '-'}
+          </span>
         </div>
       </div>
     )
@@ -73,7 +119,7 @@ const SenseiWallet = () => {
         <Tooltip title="For transactions within the 120-day holding period">
           <InfoCircleOutlined className="mx-2" />
         </Tooltip>
-        Pending amount: S${pendingAmount.toFixed(2)}
+        Pending amount: S${!isNil(pendingAmount) ? parseFloat(pendingAmount).toFixed(2) : '-'}
       </h6>
     )
   }
@@ -86,7 +132,21 @@ const SenseiWallet = () => {
       <div className="card-body">
         <ConfirmedAmountContent />
         <div className="row d-flex">
-          <div className="col-12">{showWithdrawButton()}</div>
+          <div className="col-12">
+            <WithdrawButton />
+          </div>
+          {!isWithdrawable && (
+            <div className="col-12 mt-2">
+              <small className="text-muted">
+                Confirmed amount has to be more than $0 to withdraw.
+              </small>
+            </div>
+          )}
+          {isExistingWithdrawalRequest && (
+            <div className="col-12 mt-2">
+              <small className="text-muted">There is currently a pending withdrawal request.</small>
+            </div>
+          )}
         </div>
       </div>
       <div className="card-footer">

--- a/src/services/wallet/index.js
+++ b/src/services/wallet/index.js
@@ -1,0 +1,45 @@
+import { isNil } from 'lodash'
+import apiClient from 'services/axios'
+
+// includes viewing transaction history
+export async function viewWallet(walletId) {
+  const url = `/wallet/${walletId}`
+  return apiClient
+    .get(url)
+    .then(response => {
+      if (response && !isNil(response.data)) {
+        return response.data
+      }
+      return false
+    })
+    .catch(err => console.log(err))
+}
+
+// only for Admin
+export async function viewBillings() {
+  const url = `/wallet/billings`
+  return apiClient
+    .get(url)
+    .then(response => {
+      if (response && !isNil(response.data)) {
+        return response.data
+      }
+      return false
+    })
+    .catch(err => console.log(err))
+}
+
+// only for Sensei
+// this sends a withdrawal request to the admin
+export async function requestWithdrawal(walletId) {
+  const url = `/wallet/${walletId}`
+  return apiClient
+    .put(url)
+    .then(response => {
+      if (response && !isNil(response.data)) {
+        return response.data
+      }
+      return false
+    })
+    .catch(err => console.log(err))
+}


### PR DESCRIPTION
# Feature

Use Case: 
H.2.3  View Wallet
H.2.4 Withdraw Wallet Balance

Feature ID : 9
Feature: Purchasing

# Changelog:
- see commit log

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
![Screenshot 2021-03-19 at 3 06 33 PM](https://user-images.githubusercontent.com/41737751/111746221-b1a2b800-88c8-11eb-8bba-c9353085574d.png)

![Screenshot 2021-03-19 at 3 07 41 PM](https://user-images.githubusercontent.com/41737751/111746219-b10a2180-88c8-11eb-8ee1-71aca9f310b8.png)

![Screenshot 2021-03-19 at 3 07 52 PM](https://user-images.githubusercontent.com/41737751/111746218-b10a2180-88c8-11eb-9bfe-ede7e5fe0a0d.png)

_Note_: the ss below shows the Popconfirm still showing after clicking on Withdraw but it has since been fixed in this PR
![Screenshot 2021-03-19 at 3 07 57 PM](https://user-images.githubusercontent.com/41737751/111746215-b0718b00-88c8-11eb-9ccb-1b4f49cf27f4.png)

![Screenshot 2021-03-19 at 3 38 50 PM](https://user-images.githubusercontent.com/41737751/111746619-41486680-88c9-11eb-8de9-686b222dbd09.png)


