### PR TITLE
fix showNotifications method not showing main message

### DIFF
--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -119,19 +119,19 @@ export const showNotification = (type, msg, description) => {
   switch (type) {
     case 'success':
       notification.success({
-        msg,
+        message: msg,
         description,
       })
       break
     case 'error':
       notification.error({
-        msg,
+        message: msg,
         description,
       })
       break
     case 'warn':
       notification.warn({
-        msg,
+        message: msg,
         description,
       })
       break


### PR DESCRIPTION
# Changelog:

Fix attribute name msg not being supplied to the notification antD utility. This was due to importing 'message' from antD rendering a refactor of the notification.blabla({ message, description }) to notification.blabla({ msg, description }), causing the error.

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense
