### PR TITLE
fix text overflow card when too long on sensei course card

### DIFF
--- a/src/components/Sensei/Course/SenseiCourseCard/index.js
+++ b/src/components/Sensei/Course/SenseiCourseCard/index.js
@@ -31,7 +31,7 @@ const SenseiCourseCard = data => {
           <div className="col-9">
             <div className="card-body">
               <div className="d-flex align-items-start flex-column sensei-course-card-content">
-                <div className="h5 card-title font-weight-bold truncate-2-overflow">
+                <div className="h5 card-title font-weight-bold truncate-2-overflow text-break">
                   {course.title}
                 </div>
                 <p className="card-text text-break truncate-2-overflow">{course.description}</p>

--- a/src/global.css
+++ b/src/global.css
@@ -1,3 +1,7 @@
+.description-body {
+  white-space: pre-line;
+}
+
 .mentorship-listing-card {
   height: 340px;
 }

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -61,7 +61,7 @@ const ViewCourseDetailsPublic = () => {
       <div className="row mt-4">
         <div className="col-12 col-lg-8 text-center text-lg-left order-12 order-lg-1">
           <div>
-            <h1 className="text-dark text-uppercase">
+            <h1 className="text-dark text-uppercase text-break">
               <strong>{currentCourse.title}</strong>
             </h1>
           </div>

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -84,7 +84,7 @@ const ViewCourseDetailsPublic = () => {
 
           <div className="mt-4">
             <h3>Course Description</h3>
-            <h5 className="mt-4">{currentCourse.description}</h5>
+            <h5 className="mt-4 description-body">{currentCourse.description}</h5>
           </div>
           <hr className="mt-4" />
 


### PR DESCRIPTION
# Changelog:
Fix Sensei Course Card having text overflow display when text is too long

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
<img width="803" alt="image" src="https://user-images.githubusercontent.com/43084055/111948713-8ca58380-8b1a-11eb-8358-2da4892e756f.png">
<img width="785" alt="image" src="https://user-images.githubusercontent.com/43084055/111948793-aa72e880-8b1a-11eb-8f77-4e8634fab577.png">
