### PR TITLE
Refactor generic ManagementSkeleton component

### DIFF
--- a/src/components/Admin/ManagementSkeleton/index.js
+++ b/src/components/Admin/ManagementSkeleton/index.js
@@ -32,7 +32,7 @@ const ManagementSkeleton = ({
       <div className="row mt-4">
         <div className="col-12 col-md-4">
           <CountIconWidget
-            title={`Pending  ${objectType}`}
+            title={`Pending ${objectType}`}
             className={`${currentFilter === 'pending' ? 'btn btn-light' : 'btn'}`}
             count={numPendingRequests}
             icon={<ExceptionOutlined />}
@@ -43,7 +43,7 @@ const ManagementSkeleton = ({
 
         <div className="col-6 col-md-4">
           <CountIconWidget
-            title={`Accepted  ${objectType}`}
+            title={`Accepted ${objectType}`}
             className={`${currentFilter === 'accepted' ? 'btn btn-light' : 'btn'}`}
             count={numAcceptedRequests}
             icon={<CheckOutlined />}
@@ -54,7 +54,7 @@ const ManagementSkeleton = ({
 
         <div className="col-6 col-md-4">
           <CountIconWidget
-            title={`Rejected  ${objectType}`}
+            title={`Rejected ${objectType}`}
             className={`${currentFilter === 'rejected' ? 'btn btn-light' : 'btn'}`}
             count={numRejectedRequests}
             icon={<CloseOutlined />}

--- a/src/components/Admin/ManagementSkeleton/index.js
+++ b/src/components/Admin/ManagementSkeleton/index.js
@@ -1,0 +1,86 @@
+import { CheckOutlined, CloseOutlined, ExceptionOutlined } from '@ant-design/icons'
+import { Table, Tabs } from 'antd'
+import CountIconWidget from 'components/Common/CountIconWidget'
+import React from 'react'
+import { Helmet } from 'react-helmet'
+
+const ManagementSkeleton = ({
+  currentFilter,
+  currentTableData,
+  handleAcceptedWidgetOnClick,
+  handlePendingWidgetOnClick,
+  handleRejectedWidgetOnClick,
+  numAcceptedRequests,
+  numPendingRequests,
+  numRejectedRequests,
+  objectType,
+  pageTitle,
+  tableColumns,
+}) => {
+  const { TabPane } = Tabs
+  return (
+    <div>
+      <div className="row">
+        <Helmet title={pageTitle} />
+        <div className="col-auto">
+          <div className="text-dark text-uppercase h3">
+            <strong>{pageTitle}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="row mt-4">
+        <div className="col-12 col-md-4">
+          <CountIconWidget
+            title={`Pending  ${objectType}`}
+            className={`${currentFilter === 'pending' ? 'btn btn-light' : 'btn'}`}
+            count={numPendingRequests}
+            icon={<ExceptionOutlined />}
+            onClick={handlePendingWidgetOnClick}
+            color="orange"
+          />
+        </div>
+
+        <div className="col-6 col-md-4">
+          <CountIconWidget
+            title={`Accepted  ${objectType}`}
+            className={`${currentFilter === 'accepted' ? 'btn btn-light' : 'btn'}`}
+            count={numAcceptedRequests}
+            icon={<CheckOutlined />}
+            onClick={handleAcceptedWidgetOnClick}
+            color="green"
+          />
+        </div>
+
+        <div className="col-6 col-md-4">
+          <CountIconWidget
+            title={`Rejected  ${objectType}`}
+            className={`${currentFilter === 'rejected' ? 'btn btn-light' : 'btn'}`}
+            count={numRejectedRequests}
+            icon={<CloseOutlined />}
+            onClick={handleRejectedWidgetOnClick}
+            color="red"
+          />
+        </div>
+
+        <div className="col-12">
+          <div className="card">
+            <div className="card-header card-header-flex">
+              <div className="d-flex flex-column justify-content-center mr-auto">
+                <h5>{`List of ${objectType}`}</h5>
+              </div>
+              <Tabs activeKey={objectType} className="kit-tabs">
+                <TabPane tab={objectType} key={objectType} />
+              </Tabs>
+            </div>
+            <div className="card-body overflow-x-scroll mr-3 mr-sm-0">
+              <Table className="w-100" dataSource={currentTableData} columns={tableColumns} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ManagementSkeleton

--- a/src/pages/admin/courses/index.js
+++ b/src/pages/admin/courses/index.js
@@ -1,22 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { Helmet } from 'react-helmet'
 import { isNil, map, size } from 'lodash'
-import {
-  ACCEPTED_COURSES,
-  COURSE_CONTENT_MGT,
-  PENDING_COURSES,
-  REJECTED_COURSES,
-} from 'constants/text'
-import { ADMIN_VERIFIED_ENUM, VISIBILITY_ENUM } from 'constants/constants'
-import CountIconWidget from 'components/Common/CountIconWidget'
-import {
-  CheckOutlined,
-  CloseOutlined,
-  ExceptionOutlined,
-  InfoCircleOutlined,
-} from '@ant-design/icons'
-import { Button, Space, Table, Tabs } from 'antd'
+import { COURSES, COURSE_CONTENT_MGT } from 'constants/text'
+import { ADMIN_VERIFIED_ENUM } from 'constants/constants'
+import { CheckOutlined, CloseOutlined, InfoCircleOutlined } from '@ant-design/icons'
+import { Button, Space } from 'antd'
 import { formatTime, showNotification } from 'components/utils'
 import StatusTag from 'components/Common/StatusTag'
 import {
@@ -32,9 +20,10 @@ import {
   ERROR,
   SUCCESS,
 } from 'constants/notifications'
+import { ADMIN_VERIFIED_ENUM_FILTER, VISIBILITY_ENUM_FILTER } from 'constants/filters'
+import ManagementSkeleton from 'components/Admin/ManagementSkeleton'
 
 const CourseContentManagement = () => {
-  const { TabPane } = Tabs
   const history = useHistory()
 
   const [allRequests, setAllRequests] = useState([])
@@ -154,14 +143,7 @@ const CourseContentManagement = () => {
       title: 'Verification Status',
       dataIndex: 'adminVerified',
       key: 'adminVerified',
-      filters: [
-        {
-          text: ADMIN_VERIFIED_ENUM.PENDING,
-          value: ADMIN_VERIFIED_ENUM.PENDING,
-        },
-        { text: ADMIN_VERIFIED_ENUM.ACCEPTED, value: ADMIN_VERIFIED_ENUM.ACCEPTED },
-        { text: ADMIN_VERIFIED_ENUM.REJECTED, value: ADMIN_VERIFIED_ENUM.REJECTED },
-      ],
+      filters: ADMIN_VERIFIED_ENUM_FILTER,
       onFilter: (value, record) => record.adminVerified.indexOf(value) === 0,
       render: record => <StatusTag data={{ adminVerified: record }} />,
     },
@@ -170,13 +152,7 @@ const CourseContentManagement = () => {
       dataIndex: 'visibility',
       key: 'visibility',
       responsive: ['md'],
-      filters: [
-        {
-          text: VISIBILITY_ENUM.PUBLISHED,
-          value: VISIBILITY_ENUM.PUBLISHED,
-        },
-        { text: VISIBILITY_ENUM.HIDDEN, value: VISIBILITY_ENUM.HIDDEN },
-      ],
+      filters: VISIBILITY_ENUM_FILTER,
       onFilter: (value, record) => record.visibility.indexOf(value) === 0,
     },
     {
@@ -212,73 +188,35 @@ const CourseContentManagement = () => {
     },
   ]
 
+  const handleAcceptedWidgetOnClick = () => {
+    setTableData('accepted')
+  }
+  const handlePendingWidgetOnClick = () => {
+    setTableData('pending')
+  }
+  const handleRejectedWidgetOnClick = () => {
+    setTableData('rejected')
+  }
+
   useEffect(() => {
     retrieveCourseRequests()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (
-    <div>
-      <div className="row">
-        <Helmet title={COURSE_CONTENT_MGT} />
-        <div className="col-auto">
-          <div className="text-dark text-uppercase h3">
-            <strong>{COURSE_CONTENT_MGT}</strong>
-          </div>
-        </div>
-      </div>
-
-      <div className="row mt-4">
-        <div className="col-12 col-md-4">
-          <CountIconWidget
-            title={PENDING_COURSES}
-            className={`${currentFilter === 'pending' ? 'btn btn-light' : 'btn'}`}
-            count={size(pendingRequests)}
-            icon={<ExceptionOutlined />}
-            onClick={() => setTableData('pending')}
-            color="orange"
-          />
-        </div>
-
-        <div className="col-6 col-md-4">
-          <CountIconWidget
-            title={ACCEPTED_COURSES}
-            className={`${currentFilter === 'accepted' ? 'btn btn-light' : 'btn'}`}
-            count={size(acceptedRequests)}
-            icon={<CheckOutlined />}
-            onClick={() => setTableData('accepted')}
-            color="green"
-          />
-        </div>
-
-        <div className="col-6 col-md-4">
-          <CountIconWidget
-            title={REJECTED_COURSES}
-            className={`${currentFilter === 'rejected' ? 'btn btn-light' : 'btn'}`}
-            count={size(rejectedRequests)}
-            icon={<CloseOutlined />}
-            onClick={() => setTableData('rejected')}
-            color="red"
-          />
-        </div>
-
-        <div className="col-12">
-          <div className="card">
-            <div className="card-header card-header-flex">
-              <div className="d-flex flex-column justify-content-center mr-auto">
-                <h5>List of Courses</h5>
-              </div>
-              <Tabs activeKey="courses" className="kit-tabs">
-                <TabPane tab="Courses" key="courses" />
-              </Tabs>
-            </div>
-            <div className="card-body overflow-x-scroll mr-3 mr-sm-0">
-              <Table className="w-100" dataSource={currentTableData} columns={tableColumns} />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <ManagementSkeleton
+      currentFilter={currentFilter}
+      currentTableData={currentTableData}
+      handleAcceptedWidgetOnClick={handleAcceptedWidgetOnClick}
+      handlePendingWidgetOnClick={handlePendingWidgetOnClick}
+      handleRejectedWidgetOnClick={handleRejectedWidgetOnClick}
+      numAcceptedRequests={size(acceptedRequests)}
+      numPendingRequests={size(pendingRequests)}
+      numRejectedRequests={size(rejectedRequests)}
+      objectType={COURSES}
+      pageTitle={COURSE_CONTENT_MGT}
+      tableColumns={tableColumns}
+    />
   )
 }
 


### PR DESCRIPTION
# Changelog:
- make returned component in CourseContentManagement to be a generic one which accepts various props
- add `handle____WidgetOnClick` methods to `setTableData` 

Note: this current generic Management Skeleton **always assumes 3 different states: Pending/Accepted/Rejected**
I think this would fit most of our use cases for now, can always further refactor or create another generic component if there is another pattern (i.e only 2 states) 

also this generic pattern **assumes 1 tab for the table in the list**

## Checklist:
- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
Existing functionality is retained
<a href="https://www.loom.com/share/b344502a48a34fb7bcf6588a6d063496"> <p>Digi Dojo | Course Content Management | Post-Refactoring - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b344502a48a34fb7bcf6588a6d063496-with-play.gif"> </a>