### PR TITLE
B.5.17,18 Admin wallet management skeleton pages

### DIFF
--- a/src/components/Admin/UsersManagement/SenseiProfileComponent/index.js
+++ b/src/components/Admin/UsersManagement/SenseiProfileComponent/index.js
@@ -12,8 +12,9 @@ import ProfileExperienceCard from 'components/Profile/ExperienceCard'
 import ProfilePersonalityCard from 'components/Profile/PersonalityCard'
 import ProfileVerificationCard from 'components/Profile/ProfileVerificationCard'
 import ProfileUploadFilesCard from 'components/Profile/UploadFilesCard'
-import moment from 'moment'
 import { ADMIN_VERIFIED_ENUM } from 'constants/constants'
+import { formatTime } from 'components/utils'
+import billingColumns from 'components/Common/TableColumns/Billing'
 
 const { TabPane } = Tabs
 const { Column } = Table
@@ -25,9 +26,18 @@ const SenseiProfileComponent = () => {
   const [sensei, setSensei] = useState('')
   const [mentorshipListings, setMentorshipListings] = useState('')
 
-  const [tabKey, setTabKey] = useState('1')
-  const changeTab = key => {
-    setTabKey(key)
+  // for future implementation when linking with backend
+  // const [billingsSent, setBillingsSent] = useState([])
+  // const [billingsReceived, setBillingsReceived] = useState([])
+
+  const [listingsTabKey, setListingsTabKey] = useState('listings')
+  const changeListingsTab = key => {
+    setListingsTabKey(key)
+  }
+
+  const [billingsTabKey, setBillingsTabKey] = useState('received')
+  const changeBillingsTab = key => {
+    setBillingsTabKey(key)
   }
 
   useEffect(() => {
@@ -127,15 +137,25 @@ const SenseiProfileComponent = () => {
           title="Created At"
           dataIndex="createdAt"
           key="createdAt"
-          render={createdAt => moment(createdAt).format('YYYY-MM-DD h:mm:ss a')}
+          render={createdAt => formatTime(createdAt)}
         />
         <Column
           title="Updated At"
           dataIndex="updatedAt"
           key="updatedAt"
-          render={updatedAt => moment(updatedAt).format('YYYY-MM-DD h:mm:ss a')}
+          render={updatedAt => formatTime(updatedAt)}
         />
       </Table>
+    )
+  }
+
+  const showBillings = (dataSource, tableColumns) => {
+    return (
+      <Table
+        dataSource={dataSource}
+        columns={tableColumns}
+        // onRow={record => viewBilling(record)}
+      />
     )
   }
 
@@ -170,7 +190,7 @@ const SenseiProfileComponent = () => {
           <ProfilePersonalityCard user={sensei} />
         </div>
       </div>
-
+      {/* Mentorship Listings of a Sensei */}
       <div className="row mt-4">
         <div className="col-12">
           <div className="card">
@@ -178,11 +198,33 @@ const SenseiProfileComponent = () => {
               <div className="d-flex flex-column justify-content-center mr-auto">
                 <h5>Mentorship Listings</h5>
               </div>
-              <Tabs activeKey={tabKey} className="kit-tabs" onChange={changeTab}>
-                <TabPane tab="Mentorship Listings" key="1" />
+              <Tabs activeKey={listingsTabKey} className="kit-tabs" onChange={changeListingsTab}>
+                <TabPane tab="Mentorship Listings" key="listings" />
               </Tabs>
             </div>
-            <div className="card-body">{tabKey === '1' && showMentorshipListings()}</div>
+            <div className="card-body">
+              {listingsTabKey === 'listings' && showMentorshipListings()}
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Billings of a Sensei */}
+      <div className="row mt-4">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-header card-header-flex">
+              <div className="d-flex flex-column justify-content-center mr-auto">
+                <h5>Billings</h5>
+              </div>
+              <Tabs activeKey={billingsTabKey} className="kit-tabs" onChange={changeBillingsTab}>
+                <TabPane tab="Received" key="received" />
+                <TabPane tab="Sent" key="sent" />
+              </Tabs>
+            </div>
+            <div className="card-body overflow-x-scroll mr-3 mr-sm-0">
+              {billingsTabKey === 'received' && showBillings([], billingColumns)}
+              {billingsTabKey === 'sent' && showBillings([], billingColumns)}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Common/TableColumns/Billing/index.js
+++ b/src/components/Common/TableColumns/Billing/index.js
@@ -1,0 +1,68 @@
+import { Tag } from 'antd'
+import { formatTime } from 'components/utils'
+import { BILLING_TYPE_FILTER, CURRENCY_FILTERS } from 'constants/filters'
+import { isNil } from 'lodash'
+import React from 'react'
+
+const billingColumns = [
+  {
+    title: 'Date of Billing',
+    dataIndex: 'createdAt',
+    key: 'createdAt',
+    width: '10%',
+    responsive: ['sm'],
+    render: createdAt => formatTime(createdAt),
+    sorter: (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    sortDirections: ['ascend', 'descend'],
+  },
+  {
+    title: 'Billing Id',
+    dataIndex: 'billingId',
+    key: 'billingId',
+    width: '10%',
+    responsive: ['sm'],
+  },
+  {
+    title: 'Billing Type',
+    dataIndex: 'billingType',
+    key: 'billingType',
+    width: '10%',
+    responsive: ['md'],
+    render: record => {
+      return <Tag color="geekblue">{record}</Tag>
+    },
+    filters: BILLING_TYPE_FILTER,
+    onFilter: (value, record) => record.billingType.indexOf(value) === 0,
+  },
+  {
+    title: 'Product ID',
+    dataIndex: 'productId',
+    key: 'productId',
+    width: '10%',
+    responsive: ['lg'],
+    render: record => {
+      return isNil(record) ? '-' : record
+    },
+  },
+  {
+    title: 'Currency',
+    dataIndex: 'currency',
+    key: 'currency',
+    width: '10%',
+    responsive: ['md'],
+    filters: CURRENCY_FILTERS,
+    onFilter: (value, record) => record.currency.indexOf(value) === 0,
+  },
+  {
+    title: 'Amount',
+    dataIndex: 'amount',
+    key: 'amount',
+    width: '10%',
+    responsive: ['md'],
+    render: amount => parseFloat(amount).toFixed(2),
+    sorter: (a, b) => a.amount - b.amount,
+    sortDirections: ['ascend', 'descend'],
+  },
+]
+
+export default billingColumns

--- a/src/constants/text/index.js
+++ b/src/constants/text/index.js
@@ -51,3 +51,5 @@ export const WITHDRAWAL_MGT = 'Withdrawal Management'
 export const PENDING_WITHDRAWALS = 'Pending Withdrawals'
 export const APPROVED_WITHDRAWALS = 'Approved Withdrawals'
 export const REJECTED_WITHDRAWALS = 'Rejected Withdrawals'
+
+export const WALLET_MGT = 'Wallet Management'

--- a/src/pages/admin/wallets/index.js
+++ b/src/pages/admin/wallets/index.js
@@ -1,0 +1,98 @@
+import { InfoCircleOutlined } from '@ant-design/icons'
+import { Button, Table, Tabs } from 'antd'
+import { WALLET_MGT } from 'constants/text'
+import React from 'react'
+import { Helmet } from 'react-helmet'
+import { useHistory } from 'react-router-dom'
+
+const WalletManagement = () => {
+  const { TabPane } = Tabs
+  const history = useHistory()
+
+  const onButtonClick = record => {
+    const path = `/admin/user-management/sensei/${record.accountId}`
+    history.push(path)
+  }
+  const currentTableData = []
+  const tableColumns = [
+    {
+      title: 'Wallet Id',
+      key: 'walletId',
+      dataIndex: 'walletId',
+      width: '15%',
+      responsive: ['lg'],
+    },
+    {
+      title: 'Account Id',
+      dataIndex: 'accountId',
+      key: 'accountId',
+    },
+    {
+      title: 'Pending Amount',
+      dataIndex: 'pendingAmount',
+      key: 'pendingAmount',
+      render: record => record.toFixed(2),
+      sorter: (a, b) => a.pendingAmount - b.pendingAmount,
+      sortDirections: ['ascend', 'descend'],
+    },
+    {
+      title: 'Confirmed Amount',
+      dataIndex: 'confirmedAmount',
+      key: 'confirmedAmount',
+      render: record => record.toFixed(2),
+      sorter: (a, b) => a.confirmedAmount - b.confirmedAmount,
+      sortDirections: ['ascend', 'descend'],
+    },
+    {
+      title: 'Total Amount Earned',
+      dataIndex: 'totalEarned',
+      key: 'totalEarned',
+      render: record => record.toFixed(2),
+      sorter: (a, b) => a.totalEarned - b.totalEarned,
+      sortDirections: ['ascend', 'descend'],
+    },
+    {
+      title: 'Details',
+      key: 'details',
+      render: record => (
+        <Button
+          type="primary"
+          shape="round"
+          onClick={() => onButtonClick(record)}
+          icon={<InfoCircleOutlined />}
+        />
+      ),
+    },
+  ]
+  return (
+    <div>
+      <div className="row">
+        <Helmet title={WALLET_MGT} />
+        <div className="col-auto">
+          <div className="text-dark text-uppercase h3">
+            <strong>{WALLET_MGT}</strong>
+          </div>
+        </div>
+      </div>
+      <div className="row mt-4">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-header card-header-flex">
+              <div className="d-flex flex-column justify-content-center mr-auto">
+                <h5>List of Sensei Wallets</h5>
+              </div>
+              <Tabs activeKey="wallets" className="kit-tabs">
+                <TabPane tab="Wallets" key="wallets" />
+              </Tabs>
+            </div>
+            <div className="card-body overflow-x-scroll mr-3 mr-sm-0">
+              <Table className="w-100" dataSource={currentTableData} columns={tableColumns} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default WalletManagement

--- a/src/pages/billings/index.js
+++ b/src/pages/billings/index.js
@@ -1,8 +1,7 @@
-import { Table, Tag } from 'antd'
+import { Table } from 'antd'
 import SenseiWallet from 'components/Sensei/Wallet'
 import BillingCard from 'components/Billing'
-import { formatTime, showNotification } from 'components/utils'
-import { BILLING_TYPE_FILTER, CURRENCY_FILTERS } from 'constants/filters'
+import { showNotification } from 'components/utils'
 import {
   ERROR,
   SUCCESS,
@@ -14,6 +13,7 @@ import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { requestWithdrawal, viewWallet } from 'services/wallet'
+import billingColumns from 'components/Common/TableColumns/Billing'
 
 const Billings = () => {
   const history = useHistory()
@@ -49,67 +49,6 @@ const Billings = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  const columns = [
-    {
-      title: 'Date of Billing',
-      dataIndex: 'createdAt',
-      key: 'createdAt',
-      width: '10%',
-      responsive: ['sm'],
-      render: createdAt => formatTime(createdAt),
-      sorter: (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-      sortDirections: ['ascend', 'descend'],
-    },
-    {
-      title: 'Billing Id',
-      dataIndex: 'billingId',
-      key: 'billingId',
-      width: '10%',
-      responsive: ['sm'],
-    },
-    {
-      title: 'Billing Type',
-      dataIndex: 'billingType',
-      key: 'billingType',
-      width: '10%',
-      responsive: ['md'],
-      render: record => {
-        return <Tag color="geekblue">{record}</Tag>
-      },
-      filters: BILLING_TYPE_FILTER,
-      onFilter: (value, record) => record.billingType.indexOf(value) === 0,
-    },
-    {
-      title: 'Product ID',
-      dataIndex: 'productId',
-      key: 'productId',
-      width: '10%',
-      responsive: ['lg'],
-      render: record => {
-        return isNil(record) ? '-' : record
-      },
-    },
-    {
-      title: 'Currency',
-      dataIndex: 'currency',
-      key: 'currency',
-      width: '10%',
-      responsive: ['md'],
-      filters: CURRENCY_FILTERS,
-      onFilter: (value, record) => record.currency.indexOf(value) === 0,
-    },
-    {
-      title: 'Amount',
-      dataIndex: 'amount',
-      key: 'amount',
-      width: '10%',
-      responsive: ['md'],
-      render: amount => parseFloat(amount).toFixed(2),
-      sorter: (a, b) => a.amount - b.amount,
-      sortDirections: ['ascend', 'descend'],
-    },
-  ]
 
   const viewBilling = record => {
     return {
@@ -167,13 +106,17 @@ const Billings = () => {
         />
       )}
       {isSensei && (
-        <BillingCard isIncoming>{showBillings('incoming', billingsReceived, columns)}</BillingCard>
+        <BillingCard isIncoming>
+          {showBillings('incoming', billingsReceived, billingColumns)}
+        </BillingCard>
       )}
       <BillingCard isIncoming={false}>
-        {showBillings('outgoing', billingsSent, columns)}
+        {showBillings('outgoing', billingsSent, billingColumns)}
       </BillingCard>
       {!isSensei && (
-        <BillingCard isIncoming>{showBillings('incoming', billingsReceived, columns)}</BillingCard>
+        <BillingCard isIncoming>
+          {showBillings('incoming', billingsReceived, billingColumns)}
+        </BillingCard>
       )}
     </div>
   )

--- a/src/router.js
+++ b/src/router.js
@@ -206,6 +206,11 @@ const routes = [
     Component: lazy(() => import('pages/admin/transactions')),
     exact: true,
   },
+  {
+    path: '/admin/wallets',
+    Component: lazy(() => import('pages/admin/wallets')),
+    exact: true,
+  },
   // Sensei Pages
   {
     path: '/sensei',

--- a/src/services/menu/index.js
+++ b/src/services/menu/index.js
@@ -125,6 +125,11 @@ export async function getAdminMenuData() {
           key: 'transactions',
           url: '/admin/transactions',
         },
+        {
+          title: 'Wallets',
+          key: 'wallets',
+          url: '/admin/wallets',
+        },
       ],
     },
   ]


### PR DESCRIPTION
# Feature

Use Case: 
- B.5.17 | View List of Sensei Wallets
- B.5.18 | View All Billings of a Sensei

Feature ID : 14
Feature: Payment Management

# Changelog:
- see commit log

**Notes**: 

1. Implementation of B.5.18 | View All Billings of a Sensei follows that of B.3.6 View a Sensei's Mentorship Listings (which is to be redirected to the user-management page of the sensei)
2. Abstracted out billingColumns since these columns are common to both the general billing page and viewing all sensei's billings (probably also used in other places in future, perhaps for B.5.12 | View List of Received Billings)

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
<img width="1280" alt="Screenshot 2021-03-29 at 12 39 03 AM" src="https://user-images.githubusercontent.com/41737751/112760112-76bb2580-9028-11eb-8619-14927177d7c9.png">
<img width="1280" alt="Screenshot 2021-03-29 at 12 38 44 AM" src="https://user-images.githubusercontent.com/41737751/112760115-7ae74300-9028-11eb-96c1-a779be545b6a.png">
<img width="299" alt="Screenshot 2021-03-29 at 12 51 38 AM" src="https://user-images.githubusercontent.com/41737751/112760292-f1844080-9028-11eb-8d93-e479d572f0cd.png">
