### PR TITLE
A.2.25, A.2.26 Delete Transcript, Delete CV, (Misc.) Experience Card URL fix

### DIFF
--- a/src/components/Profile/ExperienceCard/index.js
+++ b/src/components/Profile/ExperienceCard/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Button, DatePicker, Empty, Form, Input, Modal, notification, Popconfirm } from 'antd'
 import { useDispatch } from 'react-redux'
 import moment from 'moment'
-import { isNil } from 'lodash'
+import { isEmpty, isNil } from 'lodash'
 import * as jwt from 'services/user'
 
 const ExperienceCard = ({ user, showEditTools, isAdmin }) => {
@@ -181,11 +181,22 @@ const ExperienceCard = ({ user, showEditTools, isAdmin }) => {
           <div className="row mt-2 text-dark align-items-center">
             <div className="col-12 h4 font-weight-bold">
               <a
+                role="button"
+                tabIndex={0}
                 className="text-dark align-items-center"
-                href={!isNil(item.companyUrl) ? item.companyUrl : '#'}
+                onClick={() => {
+                  if (!isEmpty(item.companyUrl)) {
+                    if (!item.companyUrl.match(/^https?:\/\//i)) {
+                      window.open(`http://${item.companyUrl}`)
+                    } else {
+                      window.open(item.companyUrl)
+                    }
+                  }
+                }}
+                onKeyDown={e => e.preventDefault()}
               >
                 {item.companyName}&nbsp;&nbsp;
-                {!isNil(item.companyUrl) ? (
+                {!isEmpty(item.companyUrl) ? (
                   <span className="badge badge-pill badge-dark  align-top">View</span>
                 ) : (
                   ''

--- a/src/components/Profile/PersonalInformationCard/index.js
+++ b/src/components/Profile/PersonalInformationCard/index.js
@@ -101,7 +101,7 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
     }
   }
 
-  const GetDefaultProfilePic = () => {
+  const getDefaultProfilePic = () => {
     if (user.userType === USER_TYPE_ENUM.STUDENT) {
       return <img src="/resources/images/avatars/apprentice.png" alt="Display Pic" />
     }
@@ -152,7 +152,7 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
               {user.profileImgUrl ? (
                 <img src={`${user.profileImgUrl}?${new Date().getTime()}`} alt="Display Pic" />
               ) : (
-                GetDefaultProfilePic()
+                getDefaultProfilePic()
               )}
             </div>
           </div>

--- a/src/components/Profile/UploadFilesCard/index.js
+++ b/src/components/Profile/UploadFilesCard/index.js
@@ -1,10 +1,20 @@
-import { DownloadOutlined, UploadOutlined } from '@ant-design/icons'
-import { Button, Upload, message } from 'antd'
+import { DeleteOutlined, DownloadOutlined, UploadOutlined } from '@ant-design/icons'
+import { Button, Upload, message, Space } from 'antd'
 import Axios from 'axios'
 import { isNil } from 'lodash'
 import React from 'react'
 import { useDispatch } from 'react-redux'
 import download from 'js-file-download'
+import { removeFile } from 'services/user'
+import { showNotification } from 'components/utils'
+import {
+  CV_REMOVED,
+  CV_REMOVED_ERR,
+  ERROR,
+  SUCCESS,
+  TRANSCRIPT_REMOVED,
+  TRANSCRIPT_REMOVED_ERR,
+} from 'constants/notifications'
 
 const VerifyProfileCard = ({ user, showUploadButton, accessToken }) => {
   const dispatch = useDispatch()
@@ -51,6 +61,24 @@ const VerifyProfileCard = ({ user, showUploadButton, accessToken }) => {
     })
   }
 
+  const removeFileFromServer = async type => {
+    const result = await removeFile(type)
+    if (result) {
+      if (type === 'transcript') {
+        showNotification('success', SUCCESS, TRANSCRIPT_REMOVED)
+      } else {
+        showNotification('success', SUCCESS, CV_REMOVED)
+      }
+      dispatch({
+        type: 'user/LOAD_CURRENT_ACCOUNT',
+      })
+    } else if (type === 'transcript') {
+      showNotification('error', ERROR, TRANSCRIPT_REMOVED_ERR)
+    } else {
+      showNotification('error', ERROR, CV_REMOVED_ERR)
+    }
+  }
+
   const UploadFileComponent = data => {
     return (
       <Upload {...getUploadProps(data.isTranscript)}>
@@ -63,15 +91,27 @@ const VerifyProfileCard = ({ user, showUploadButton, accessToken }) => {
 
   const DownloadFileComponent = data => {
     return (
-      <Button
-        type="primary"
-        shape="round"
-        icon={<DownloadOutlined />}
-        size="large"
-        onClick={() => downloadFile(data.isTranscript)}
-      >
-        Download
-      </Button>
+      <Space size="large" className="mt-2 mt-sm-0">
+        <Button
+          type="primary"
+          shape="round"
+          icon={<DownloadOutlined />}
+          size="large"
+          onClick={() => downloadFile(data.isTranscript)}
+        >
+          Download
+        </Button>
+        <Button
+          ghost
+          type="danger"
+          shape="round"
+          icon={<DeleteOutlined />}
+          size="large"
+          onClick={() => removeFileFromServer(data.isTranscript ? 'transcript' : 'cv')}
+        >
+          Remove
+        </Button>
+      </Space>
     )
   }
 

--- a/src/constants/notifications/index.js
+++ b/src/constants/notifications/index.js
@@ -61,3 +61,8 @@ export const MENTORSHIP_ALR_IN = 'Mentorship Application is already in Cart'
 
 export const DP_REMOVED = 'Your Display Picture was successfully removed.'
 export const NO_DP_TO_REMOVE = 'No Display Picture to remove.'
+
+export const TRANSCRIPT_REMOVED = 'Your transcript was successfully removed.'
+export const TRANSCRIPT_REMOVED_ERR = 'There was an error removing your transcript.'
+export const CV_REMOVED = 'Your CV was successfully removed.'
+export const CV_REMOVED_ERR = 'There was an error removing your CV.'

--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -447,7 +447,7 @@ export function* DELETE_DP() {
     },
   })
 
-  const response = yield call(jwt.removeDp)
+  const response = yield call(jwt.removeFile, 'dp')
   if (response) {
     const updatedUser = handleProfileUpdateRsp(response)
     if (updatedUser) {

--- a/src/services/user/index.js
+++ b/src/services/user/index.js
@@ -270,9 +270,13 @@ export async function deleteAccount(accountId) {
     .catch(err => console.log(err))
 }
 
-export async function removeDp() {
+export async function removeFile(type) {
+  if (['dp', 'cv', 'transcript'].indexOf(type) === -1) {
+    return false
+  }
+
   return apiClient
-    .delete(`upload/user/dp`, { withCredentials: true })
+    .delete(`upload/user/${type}`, { withCredentials: true })
     .then(response => {
       if (!isNil(response.data)) {
         if (!isNil(response.data.success)) return response.data.user


### PR DESCRIPTION
# Feature

Use Case: A.2.25, A.2.26 Delete Transcript, Delete CV
Feature ID: 3 
Feature: Sensei/Student Profile

# Changelog:

Added in a small fix for Experience card whereby the View button still shows even when there's no valid URL.
Add removeFile function for Transcript, CV and merged DP removal function into the same function (since backend has the same endpoint).
TODO: one day we need to rearrange the notifications constants by a clearer order (idk what order yet tho XD)

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
<img width="663" alt="image" src="https://user-images.githubusercontent.com/43084055/112807430-79f6f580-90aa-11eb-8eb1-272d110c52ad.png">
<img width="967" alt="image" src="https://user-images.githubusercontent.com/43084055/112807436-7cf1e600-90aa-11eb-8203-92d31b4b5478.png">
<img width="344" alt="image" src="https://user-images.githubusercontent.com/43084055/112807457-82e7c700-90aa-11eb-98be-76183f0ca4ff.png">
