### PR TITLE
B.5.12 View List of Received Billings

### DIFF
--- a/src/components/Admin/AdminManagement/AdminProfile/index.js
+++ b/src/components/Admin/AdminManagement/AdminProfile/index.js
@@ -379,8 +379,11 @@ const AdminProfile = () => {
                     rules={[{ required: true, message: 'Please input role' }]}
                   >
                     <Select placeholder="Select Admin Role">
-                      <Option value="ADMIN">ADMIN</Option>
-                      <Option value="SUPERADMIN">SUPERADMIN</Option>
+                      <Option value={ADMIN_ROLE_ENUM.ADMIN}>{ADMIN_ROLE_ENUM.ADMIN}</Option>
+                      <Option value={ADMIN_ROLE_ENUM.FINANCE}>{ADMIN_ROLE_ENUM.FINANCE}</Option>
+                      <Option value={ADMIN_ROLE_ENUM.SUPERADMIN}>
+                        {ADMIN_ROLE_ENUM.SUPERADMIN}
+                      </Option>
                     </Select>
                   </Form.Item>
                 </div>

--- a/src/components/Admin/BillingManagement/BillingCountIconWidget/index.js
+++ b/src/components/Admin/BillingManagement/BillingCountIconWidget/index.js
@@ -1,0 +1,40 @@
+import { CarryOutOutlined, SendOutlined, TransactionOutlined } from '@ant-design/icons'
+import CountIconWidget from 'components/Common/CountIconWidget'
+import { size } from 'lodash'
+import React from 'react'
+
+const BillingCountIconWidget = ({ allBillings, allReceived, allSent, objectType, switchTabs }) => {
+  return (
+    <div className="row mt-4">
+      <div className="col-12 col-md-4">
+        <CountIconWidget
+          title={`Total ${objectType}`}
+          className="btn"
+          count={size(allBillings)}
+          icon={<TransactionOutlined />}
+          onClick={() => switchTabs('all')}
+        />
+      </div>
+      <div className="col-12 col-md-4">
+        <CountIconWidget
+          title={`Total Received ${objectType}`}
+          className="btn"
+          count={size(allReceived)}
+          icon={<CarryOutOutlined />}
+          onClick={() => switchTabs('received')}
+        />
+      </div>
+      <div className="col-12 col-md-4">
+        <CountIconWidget
+          title={`Total Sent ${objectType}`}
+          className="btn"
+          count={size(allSent)}
+          icon={<SendOutlined />}
+          onClick={() => switchTabs('sent')}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default BillingCountIconWidget

--- a/src/components/Admin/BillingManagement/index.js
+++ b/src/components/Admin/BillingManagement/index.js
@@ -1,0 +1,75 @@
+import { Table, Tabs } from 'antd'
+import { BILLINGS, BILLING_MGT } from 'constants/text'
+import React, { useEffect, useState } from 'react'
+import { Helmet } from 'react-helmet'
+import BillingCountIconWidget from './BillingCountIconWidget'
+
+const BillingManagement = ({ allReceived, allSent, tableColumns, allBillings }) => {
+  const { TabPane } = Tabs
+  const [currentTab, setCurrentTab] = useState('all')
+  const [currentTableData, setCurrentTableData] = useState([])
+
+  const switchTabs = key => {
+    setCurrentTab(key)
+    if (key === 'received') {
+      setCurrentTableData(allReceived)
+    }
+    if (key === 'sent') {
+      setCurrentTableData(allSent)
+    }
+    if (key === 'all') {
+      setCurrentTableData(allBillings)
+    }
+  }
+
+  useEffect(() => {
+    setCurrentTableData(allBillings)
+  }, [allBillings])
+
+  return (
+    <div>
+      <div className="row">
+        <Helmet title={BILLING_MGT} />
+        <div className="col-auto">
+          <div className="text-dark text-uppercase h3">
+            <strong>{BILLING_MGT}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="row mt-4">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-header card-header-flex">
+              <div className="d-flex flex-column justify-content-center mr-auto">
+                <h5>List of {BILLINGS}</h5>
+              </div>
+              <Tabs activeKey={currentTab} className="kit-tabs" onChange={key => switchTabs(key)}>
+                <TabPane tab="All" key="all" />
+                <TabPane tab="Received" key="received" />
+                <TabPane tab="Sent" key="sent" />
+              </Tabs>
+            </div>
+
+            <div className="card-body">
+              <BillingCountIconWidget
+                allSent={allSent}
+                allReceived={allReceived}
+                allBillings={allBillings}
+                switchTabs={switchTabs}
+                objectType={BILLINGS}
+              />
+              <div className="row">
+                <div className="col-12 overflow-x-scroll">
+                  <Table dataSource={currentTableData} columns={tableColumns} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BillingManagement

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,4 +1,5 @@
 import { notification, message } from 'antd'
+import { DIRECTION } from 'constants/constants'
 import { isNil, map } from 'lodash'
 import moment from 'moment'
 
@@ -6,28 +7,33 @@ export const formatTime = dateTime => {
   return moment(dateTime).format('DD MMM YYYY h:mm:ss a')
 }
 
-export const sortArrByCreatedAtAsc = objArr => {
-  return objArr.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+export const sortArrByCreatedAt = (objArr, direction) => {
+  if (direction === DIRECTION.ASC) {
+    return objArr.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+  }
+  // for descending
+  return objArr.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 }
 
 export const sortDescAndKeyAccId = data => {
-  return map(
-    data.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-    user => ({
-      ...user,
-      key: user.accountId,
-    }),
-  )
+  return map(sortArrByCreatedAt(data, DIRECTION.DESC), user => ({
+    ...user,
+    key: user.accountId,
+  }))
 }
 
 export const sortDescAndKeyCourseId = data => {
-  return map(
-    data.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-    user => ({
-      ...user,
-      key: user.courseId,
-    }),
-  )
+  return map(sortArrByCreatedAt(data, DIRECTION.DESC), user => ({
+    ...user,
+    key: user.courseId,
+  }))
+}
+
+export const sortDescAndKeyBillingId = data => {
+  return map(sortArrByCreatedAt(data, DIRECTION.DESC), billing => ({
+    ...billing,
+    key: billing.billingId,
+  }))
 }
 
 export const filterDataByAdminVerified = (data, adminVerified) => {

--- a/src/constants/constants/index.js
+++ b/src/constants/constants/index.js
@@ -94,3 +94,8 @@ export const BILLING_STATUS = {
   WITHDRAWN: 'WITHDRAWN',
   ADMIN: 'ADMIN',
 }
+
+export const DIRECTION = {
+  ASC: 'ASCENDING',
+  DESC: 'DESCENDING',
+}

--- a/src/constants/text/index.js
+++ b/src/constants/text/index.js
@@ -53,3 +53,6 @@ export const APPROVED_WITHDRAWALS = 'Approved Withdrawals'
 export const REJECTED_WITHDRAWALS = 'Rejected Withdrawals'
 
 export const WALLET_MGT = 'Wallet Management'
+
+export const BILLINGS = 'Billings'
+export const BILLING_MGT = 'Billing Management'

--- a/src/pages/billings/index.js
+++ b/src/pages/billings/index.js
@@ -15,6 +15,7 @@ import { useHistory } from 'react-router-dom'
 import { requestWithdrawal, viewWallet } from 'services/wallet'
 import billingColumns from 'components/Common/TableColumns/Billing'
 import BillingManagement from 'components/Admin/BillingManagement'
+import { USER_TYPE_ENUM } from 'constants/constants'
 
 const Billings = () => {
   const history = useHistory()
@@ -27,9 +28,9 @@ const Billings = () => {
   const { walletId } = user
   const { confirmedAmount, pendingAmount, totalEarned } = wallet
 
-  const isSensei = user.userType === 'SENSEI'
-  const isAdmin = user.userType === 'ADMIN'
-  const isStudent = user.userType === 'STUDENT'
+  const isSensei = user.userType === USER_TYPE_ENUM.SENSEI
+  const isAdmin = user.userType === USER_TYPE_ENUM.ADMIN
+  const isStudent = user.userType === USER_TYPE_ENUM.STUDENT
 
   const getWallet = async () => {
     const result = await viewWallet(walletId)

--- a/src/router.js
+++ b/src/router.js
@@ -192,8 +192,13 @@ const routes = [
     exact: true,
   },
   {
-    path: '/admin/transactions',
-    Component: lazy(() => import('pages/admin/transactions')),
+    path: '/admin/billings',
+    Component: lazy(() => import('pages/billings')),
+    exact: true,
+  },
+  {
+    path: '/admin/billing/view/:id',
+    Component: lazy(() => import('pages/billings/view')),
     exact: true,
   },
   {

--- a/src/services/menu/index.js
+++ b/src/services/menu/index.js
@@ -121,9 +121,9 @@ export async function getAdminMenuData() {
           url: '/admin/refunds',
         },
         {
-          title: 'Transactions',
-          key: 'transactions',
-          url: '/admin/transactions',
+          title: 'Billings',
+          key: 'billings',
+          url: '/admin/billings',
         },
         {
           title: 'Wallets',


### PR DESCRIPTION
# Feature

Use Case: B.5.12 View List of Received Billings
Feature ID : 14
Feature: Payment Management

since this follows the general structure of the admin management page, this PR will also address:
- view all billings as an admin
- view sent billings as an admin
^ note that both of these are not documented

# Changelog:
- see commit log
- note: pages/billings is a generic page which shows different components according to userType. rationale was that the logic, api calling was the same for all 3 userTypes.

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
<a href="https://www.loom.com/share/737f45189a7f49c3a4420d66795e37a8"> <p>Digi Dojo | Admin Billing Management - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/737f45189a7f49c3a4420d66795e37a8-with-play.gif"> </a>

Other User Types: 
Sensei (part1)
![Screenshot 2021-03-29 at 6 18 38 PM (2)](https://user-images.githubusercontent.com/41737751/112824478-280b9b00-90bd-11eb-96a6-fbec85188187.png)
Sensei (part2)
![Screenshot 2021-03-29 at 6 18 43 PM (2)](https://user-images.githubusercontent.com/41737751/112824469-24781400-90bd-11eb-97a5-29e8d3e6fc96.png)
Student
![Screenshot 2021-03-29 at 6 18 17 PM (2)](https://user-images.githubusercontent.com/41737751/112824482-28a43180-90bd-11eb-810f-5c3602196830.png)
