### PR TITLE
Use cache for profile images that do not require hot reload, Rename alt tags for logo image

### DIFF
--- a/src/components/Cart/ProductCard/index.js
+++ b/src/components/Cart/ProductCard/index.js
@@ -196,11 +196,7 @@ const ProductCard = data => {
           <div className="col-auto pl-2">
             <Avatar
               size={32}
-              src={
-                sensei.profileImgUrl
-                  ? `${sensei.profileImgUrl}?${new Date().getTime()}`
-                  : GetDefaultProfilePic()
-              }
+              src={sensei.profileImgUrl ? sensei.profileImgUrl : GetDefaultProfilePic()}
             />
           </div>
           <div className="col pl-0">
@@ -240,11 +236,7 @@ const ProductCard = data => {
           <div className="col-auto pl-2">
             <Avatar
               size={64}
-              src={
-                sensei.profileImgUrl
-                  ? `${sensei.profileImgUrl}?${new Date().getTime()}`
-                  : GetDefaultProfilePic()
-              }
+              src={sensei.profileImgUrl ? sensei.profileImgUrl : GetDefaultProfilePic()}
             />
           </div>
           <div className="col pl-2">

--- a/src/components/Common/Social/AddPostCard/index.js
+++ b/src/components/Common/Social/AddPostCard/index.js
@@ -94,9 +94,7 @@ const SocialAddPostCard = ({ user, getPostsSvc }) => {
           <div className="col-auto">
             <Avatar
               src={
-                user.profileImgUrl
-                  ? `${user.profileImgUrl}?${new Date().getTime()}`
-                  : '/resources/images/avatars/avatar-2.png'
+                user.profileImgUrl ? user.profileImgUrl : '/resources/images/avatars/avatar-2.png'
               }
             />
           </div>

--- a/src/components/Common/Social/FollowerRequestList/index.js
+++ b/src/components/Common/Social/FollowerRequestList/index.js
@@ -73,8 +73,8 @@ const FollowerRequestList = ({ pendingFollowerList, setShowSocialModal }) => {
                   icon={<UserOutlined />}
                   src={
                     userRowItem.profileImgUrl
-                      ? `${userRowItem.profileImgUrl}?${new Date().getTime()}`
-                      : null
+                      ? userRowItem.profileImgUrl
+                      : '/resources/images/avatars/avatar-2.png'
                   }
                 />
               </div>

--- a/src/components/Common/Social/FollowingList/index.js
+++ b/src/components/Common/Social/FollowingList/index.js
@@ -73,8 +73,8 @@ const SocialFollowingList = ({ followingList, isFollowingList, isOwnList, setSho
                   icon={<UserOutlined />}
                   src={
                     userRowItem.profileImgUrl
-                      ? `${userRowItem.profileImgUrl}?${new Date().getTime()}`
-                      : null
+                      ? userRowItem.profileImgUrl
+                      : '/resources/images/avatars/avatar-2.png'
                   }
                 />
               </div>

--- a/src/components/Common/Social/PostComment/Item/index.js
+++ b/src/components/Common/Social/PostComment/Item/index.js
@@ -63,7 +63,7 @@ const PostCommentItem = ({ comment, isLoading, showCommentModalWithOptions }) =>
         <Avatar
           src={
             comment.User?.profileImgUrl
-              ? `${comment.User.profileImgUrl}?${new Date().getTime()}`
+              ? comment.User.profileImgUrl
               : '/resources/images/avatars/avatar-2.png'
           }
         />

--- a/src/components/Common/Social/PostComment/index.js
+++ b/src/components/Common/Social/PostComment/index.js
@@ -372,7 +372,7 @@ const PostComments = ({ user, post, setNumComments }) => {
                 <Avatar
                   src={
                     user.profileImgUrl
-                      ? `${user.profileImgUrl}?${new Date().getTime()}`
+                      ? user.profileImgUrl
                       : '/resources/images/avatars/avatar-2.png'
                   }
                 />

--- a/src/components/Common/Social/PostList/Item/index.js
+++ b/src/components/Common/Social/PostList/Item/index.js
@@ -78,7 +78,7 @@ const SocialPostListItem = ({ user, post, isLoading, showPostModalWithOptions, b
                 size="large"
                 src={
                   post.User?.profileImgUrl
-                    ? `${post.User?.profileImgUrl}?${new Date().getTime()}`
+                    ? post.User.profileImgUrl
                     : '/resources/images/avatars/avatar-2.png'
                 }
               />

--- a/src/components/Common/Social/ProfileCard/index.js
+++ b/src/components/Common/Social/ProfileCard/index.js
@@ -60,7 +60,7 @@ const SocialProfileCard = ({ user, setCurrentTab }) => {
           <Avatar
             size={75}
             icon={<UserOutlined />}
-            src={user.profileImgUrl ? `${user.profileImgUrl}?${new Date().getTime()}` : null}
+            src={user.profileImgUrl ? user.profileImgUrl : '/resources/images/avatars/avatar-2.png'}
           />
         </div>
       </div>

--- a/src/components/Course/CourseListingCard/index.js
+++ b/src/components/Course/CourseListingCard/index.js
@@ -70,7 +70,7 @@ const CourseListingCard = data => {
                   size={32}
                   icon={<UserOutlined />}
                   src={
-                    !isNil(course.Sensei?.profileImgUrl)
+                    course.Sensei?.profileImgUrl
                       ? course.Sensei.profileImgUrl
                       : '/resources/images/avatars/master.png'
                   }

--- a/src/components/Course/LessonComments/CommentGridItem/index.js
+++ b/src/components/Course/LessonComments/CommentGridItem/index.js
@@ -43,7 +43,7 @@ const CommentGridItem = ({ comment, user, isLoading, handleDelete, handleReport,
         <Avatar
           src={
             comment.User?.profileImgUrl
-              ? `${comment.User.profileImgUrl}?${new Date().getTime()}`
+              ? comment.User.profileImgUrl
               : '/resources/images/avatars/avatar-2.png'
           }
         />

--- a/src/components/Course/LessonComments/index.js
+++ b/src/components/Course/LessonComments/index.js
@@ -218,11 +218,7 @@ const LessonComments = ({ lessonId, currentLesson, isAdmin }) => {
       {!isAdmin && (
         <div className="col-auto">
           <Avatar
-            src={
-              user.profileImgUrl
-                ? `${user.profileImgUrl}?${new Date().getTime()}`
-                : '/resources/images/avatars/avatar-2.png'
-            }
+            src={user.profileImgUrl ? user.profileImgUrl : '/resources/images/avatars/avatar-2.png'}
           />
         </div>
       )}

--- a/src/components/Mentorship/ListingDetails/MentorshipProfilePicture.js
+++ b/src/components/Mentorship/ListingDetails/MentorshipProfilePicture.js
@@ -13,8 +13,8 @@ const MentorshipProfilePicture = ({ listing }) => {
       size={104}
       icon={<UserOutlined />}
       src={
-        listing?.Sensei?.profileImgUrl
-          ? `${listing?.Sensei?.profileImgUrl}?${new Date().getTime()}`
+        listing.Sensei?.profileImgUrl
+          ? listing.Sensei?.profileImgUrl
           : '/resources/images/avatars/avatar-2.png'
       }
     />

--- a/src/components/Mentorship/ShoppingListCard/index.js
+++ b/src/components/Mentorship/ShoppingListCard/index.js
@@ -35,8 +35,8 @@ const MentorshipListingCard = data => {
                 size={42}
                 icon={<UserOutlined />}
                 src={
-                  listing?.Sensei?.profileImgUrl
-                    ? `${listing?.Sensei?.profileImgUrl}?${new Date().getTime()}`
+                  listing.Sensei?.profileImgUrl
+                    ? listing.Sensei?.profileImgUrl
                     : '/resources/images/avatars/avatar-2.png'
                 }
               />

--- a/src/components/Public/PublicMenuBar/MenuLeft/index.js
+++ b/src/components/Public/PublicMenuBar/MenuLeft/index.js
@@ -7,6 +7,7 @@ import store from 'store'
 import PerfectScrollbar from 'react-perfect-scrollbar'
 import { find } from 'lodash'
 import UserMenu from 'components/UserActionGroup/UserMenu'
+import { DIGI_DOJO } from 'constants/text'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ menu, settings, user }) => ({
@@ -191,7 +192,7 @@ const MenuLeft = ({
       >
         <div className={style.logoContainer}>
           <div className={style.logo}>
-            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
+            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt={DIGI_DOJO} />
             <div className={style.name}>{logo}</div>
             {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
           </div>

--- a/src/components/Public/PublicMenuBar/MenuLeft/index.js
+++ b/src/components/Public/PublicMenuBar/MenuLeft/index.js
@@ -191,7 +191,7 @@ const MenuLeft = ({
       >
         <div className={style.logoContainer}>
           <div className={style.logo}>
-            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Clean UI" />
+            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
             <div className={style.name}>{logo}</div>
             {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
           </div>

--- a/src/components/Public/PublicMenuBar/MenuTop/index.js
+++ b/src/components/Public/PublicMenuBar/MenuTop/index.js
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import store from 'store'
 import { find } from 'lodash'
 import UserActionGroup from 'components/UserActionGroup'
+import { DIGI_DOJO } from 'constants/text'
 import style from './style.module.scss'
 import Search from '../Search'
 
@@ -133,7 +134,7 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
+          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt={DIGI_DOJO} />
           <div className={style.name}>{logo}</div>
         </div>
       </div>

--- a/src/components/Public/PublicMenuBar/MenuTop/index.js
+++ b/src/components/Public/PublicMenuBar/MenuTop/index.js
@@ -133,7 +133,7 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Clean UI" />
+          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
           <div className={style.name}>{logo}</div>
         </div>
       </div>

--- a/src/components/cleanui/layout/Menu/MenuLeft/index.js
+++ b/src/components/cleanui/layout/Menu/MenuLeft/index.js
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import store from 'store'
 import PerfectScrollbar from 'react-perfect-scrollbar'
 import { find } from 'lodash'
+import { DIGI_DOJO } from 'constants/text'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ menu, settings, user }) => ({
@@ -189,7 +190,7 @@ const MenuLeft = ({
       >
         <div className={style.logoContainer}>
           <div className={style.logo}>
-            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
+            <img src="/resources/images/logo.svg" width="32" className="mr-2" alt={DIGI_DOJO} />
             <div className={style.name}>{logo}</div>
           </div>
         </div>

--- a/src/components/cleanui/layout/Menu/MenuTop/index.js
+++ b/src/components/cleanui/layout/Menu/MenuTop/index.js
@@ -131,7 +131,7 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Clean UI" />
+          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
           <div className={style.name}>{logo}</div>
         </div>
       </div>

--- a/src/components/cleanui/layout/Menu/MenuTop/index.js
+++ b/src/components/cleanui/layout/Menu/MenuTop/index.js
@@ -5,6 +5,7 @@ import { Link, withRouter } from 'react-router-dom'
 import classNames from 'classnames'
 import store from 'store'
 import { find } from 'lodash'
+import { DIGI_DOJO } from 'constants/text'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ menu, settings, user }) => ({
@@ -131,7 +132,7 @@ const MenuTop = ({
     >
       <div className={style.logoContainer}>
         <div className={style.logo}>
-          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
+          <img src="/resources/images/logo.svg" width="32" className="mr-2" alt={DIGI_DOJO} />
           <div className={style.name}>{logo}</div>
         </div>
       </div>

--- a/src/layouts/Auth/index.js
+++ b/src/layouts/Auth/index.js
@@ -46,7 +46,7 @@ const AuthLayout = ({
           >
             <div className={style.logoContainer}>
               <a href="/" className={style.logo}>
-                <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Clean UI" />
+                <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
                 <div className={style.name}>{logo}</div>
                 {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
               </a>

--- a/src/layouts/Auth/index.js
+++ b/src/layouts/Auth/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Layout } from 'antd'
 import { Link, withRouter } from 'react-router-dom'
 import classNames from 'classnames'
+import { DIGI_DOJO } from 'constants/text'
 import style from './style.module.scss'
 
 const mapStateToProps = ({ settings }) => ({
@@ -46,7 +47,7 @@ const AuthLayout = ({
           >
             <div className={style.logoContainer}>
               <a href="/" className={style.logo}>
-                <img src="/resources/images/logo.svg" width="32" className="mr-2" alt="Digi Dojo" />
+                <img src="/resources/images/logo.svg" width="32" className="mr-2" alt={DIGI_DOJO} />
                 <div className={style.name}>{logo}</div>
                 {logo === 'Clean UI Pro' && <div className={style.descr}>React</div>}
               </a>

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -145,11 +145,14 @@ const ViewCourseDetailsPublic = () => {
                 <div className="row mt-2 align-items-center">
                   <div className="col-auto">
                     <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
-                      {currentSensei.profileImgUrl ? (
-                        <img src={currentSensei.profileImgUrl} alt="Display Pic" />
-                      ) : (
-                        <img src="/resources/images/avatars/master.png" alt="Display Pic" />
-                      )}
+                      <img
+                        src={
+                          currentSensei.profileImgUrl
+                            ? currentSensei.profileImgUrl
+                            : '/resources/images/avatars/master.png'
+                        }
+                        alt="Display Pic"
+                      />
                     </div>
                   </div>
                 </div>

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -146,10 +146,7 @@ const ViewCourseDetailsPublic = () => {
                   <div className="col-auto">
                     <div className="kit__utils__avatar kit__utils__avatar--size64 mb-3">
                       {currentSensei.profileImgUrl ? (
-                        <img
-                          src={`${currentSensei.profileImgUrl}?${new Date().getTime()}`}
-                          alt="Display Pic"
-                        />
+                        <img src={currentSensei.profileImgUrl} alt="Display Pic" />
                       ) : (
                         <img src="/resources/images/avatars/master.png" alt="Display Pic" />
                       )}


### PR DESCRIPTION
# Changelog:

remove getTime() from images where no hot reload is possible, rename alt tags for logo images

hot reload is only triggered when uploading a new profile pic, which is not triggered on any of these pages. therefore, it is ok to use the cached version of the image and not load the same image multiple times

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
