### PR TITLE
common share btn, cleanup css, enable redirect from external /social/profile links

### DIFF
--- a/src/components/Common/Social/FollowerRequestList/index.js
+++ b/src/components/Common/Social/FollowerRequestList/index.js
@@ -62,7 +62,7 @@ const FollowerRequestList = ({ pendingFollowerList, setShowSocialModal }) => {
           <div
             role="button"
             tabIndex={0}
-            className="col-7 col-md-9 invisible-btn defocus-btn"
+            className="col-7 col-md-9 clickable defocus-btn"
             onClick={() => socialProfileOverride(userRowItem.accountId)}
             onKeyDown={e => e.preventDefault()}
           >

--- a/src/components/Common/Social/FollowingList/index.js
+++ b/src/components/Common/Social/FollowingList/index.js
@@ -62,7 +62,7 @@ const SocialFollowingList = ({ followingList, isFollowingList, isOwnList, setSho
           <div
             role="button"
             tabIndex={0}
-            className="col-7 col-md-9 invisible-btn defocus-btn"
+            className="col-7 col-md-9 clickable defocus-btn"
             onClick={() => socialProfileOverride(userRowItem.accountId)}
             onKeyDown={e => e.preventDefault()}
           >

--- a/src/components/Common/Social/PostComment/Item/index.js
+++ b/src/components/Common/Social/PostComment/Item/index.js
@@ -74,7 +74,7 @@ const PostCommentItem = ({ comment, isLoading, showCommentModalWithOptions }) =>
             <span
               role="button"
               tabIndex={0}
-              className="invisible-btn font-weight-bold"
+              className="clickable font-weight-bold"
               onClick={() => sendToSocialProfile(history, user, comment.User?.accountId)}
               onKeyDown={e => e.preventDefault()}
             >
@@ -92,7 +92,11 @@ const PostCommentItem = ({ comment, isLoading, showCommentModalWithOptions }) =>
         </div>
       </div>
       <div className="col-auto align-self-start">
-        <Dropdown overlay={<CommentMenu />} trigger={['click']}>
+        <Dropdown
+          overlay={<CommentMenu />}
+          trigger={['click']}
+          overlayStyle={{ boxShadow: '2px 3px 5px 1px rgba(0, 0, 0, .1)' }}
+        >
           <Button type="text" icon={<MoreOutlined />} />
         </Dropdown>
       </div>

--- a/src/components/Common/Social/PostList/Item/index.js
+++ b/src/components/Common/Social/PostList/Item/index.js
@@ -87,7 +87,7 @@ const SocialPostListItem = ({ user, post, isLoading, showPostModalWithOptions, b
               <span
                 role="button"
                 tabIndex={0}
-                className="invisible-btn font-weight-bold font-size-18"
+                className="clickable font-weight-bold font-size-18"
                 onClick={() => sendToSocialProfile(history, user, post.User?.accountId)}
                 onKeyDown={e => e.preventDefault()}
               >
@@ -100,7 +100,11 @@ const SocialPostListItem = ({ user, post, isLoading, showPostModalWithOptions, b
             </div>
             <div className="col-auto align-self-start">
               {user.accountId === post.accountId && (
-                <Dropdown overlay={<PostMenu />} trigger={['click']}>
+                <Dropdown
+                  overlay={<PostMenu />}
+                  trigger={['click']}
+                  overlayStyle={{ boxShadow: '2px 3px 5px 1px rgba(0, 0, 0, .1)' }}
+                >
                   <Button
                     type="default"
                     size="large"
@@ -150,7 +154,7 @@ const SocialPostListItem = ({ user, post, isLoading, showPostModalWithOptions, b
             <div
               role="button"
               tabIndex={0}
-              className="invisible-btn defocus-btn col-12 col-lg text-left text-lg-right mt-2 mb-3 mt-lg-0 mb-lg-0 order-1 order-lg-12"
+              className="clickable defocus-btn col-12 col-lg text-left text-lg-right mt-2 mb-3 mt-lg-0 mb-lg-0 order-1 order-lg-12"
               onClick={() => setShowInteractionBox(!showInteractionBox)}
               onKeyDown={e => e.preventDefault()}
             >

--- a/src/components/Common/Social/ProfileCard/index.js
+++ b/src/components/Common/Social/ProfileCard/index.js
@@ -69,7 +69,7 @@ const SocialProfileCard = ({ user, setCurrentTab }) => {
           <div
             role="button"
             tabIndex={0}
-            className="col-6 invisible-btn defocus-btn"
+            className="col-6 clickable defocus-btn"
             onClick={() => showSocialTab('following')}
             onKeyDown={e => e.preventDefault()}
           >
@@ -86,7 +86,7 @@ const SocialProfileCard = ({ user, setCurrentTab }) => {
           <div
             role="button"
             tabIndex={0}
-            className="col-6 text-right invisible-btn defocus-btn"
+            className="col-6 text-right clickable defocus-btn"
             onClick={() => showSocialTab('follower')}
             onKeyDown={e => e.preventDefault()}
           >

--- a/src/components/Common/Social/ShareBtn/index.js
+++ b/src/components/Common/Social/ShareBtn/index.js
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import { Button, Dropdown, Menu, Modal, Typography } from 'antd'
+import { FacebookOutlined, QrcodeOutlined, ShareAltOutlined } from '@ant-design/icons'
+import { FacebookShareButton } from 'react-share'
+import QRCode from 'react-qr-code'
+
+const ShareBtn = ({ quote, url, btnType, btnClassName, btnSize, btnShape }) => {
+  const { Paragraph } = Typography
+  const [showQRCode, setShowQRCode] = useState(false)
+
+  const ShareMenu = () => {
+    return (
+      <Menu>
+        <Menu.Item icon={<FacebookOutlined />} key="facebook" className="font-size-18">
+          <FacebookShareButton url="digi.dojo" quote={quote} hashtag="DigiDojo">
+            Facebook
+          </FacebookShareButton>
+        </Menu.Item>
+        <Menu.Divider />
+        <Menu.Item icon={<QrcodeOutlined />} key="qr" className="font-size-18">
+          <a
+            target="_blank"
+            role="button"
+            tabIndex={0}
+            onClick={() => setShowQRCode(true)}
+            onKeyDown={e => e.preventDefault()}
+          >
+            Share QR
+          </a>
+        </Menu.Item>
+      </Menu>
+    )
+  }
+
+  return (
+    <div>
+      <Dropdown
+        overlay={<ShareMenu />}
+        trigger={['click']}
+        overlayStyle={{ boxShadow: '2px 3px 5px 1px rgba(0, 0, 0, .1)' }}
+      >
+        <Button
+          type={btnType || 'default'}
+          size={btnSize || 'large'}
+          className={btnClassName || ''}
+          shape={btnShape || false}
+          icon={<ShareAltOutlined />}
+        >
+          Share
+        </Button>
+      </Dropdown>
+      <Modal
+        title="View QR"
+        visible={showQRCode}
+        cancelText="Close"
+        centered
+        okButtonProps={{ style: { display: 'none' } }}
+        onCancel={() => setShowQRCode(false)}
+        zIndex="1051"
+      >
+        <div className="row mt-3">
+          <div className="col-12 text-center">
+            <QRCode value={url} />
+            <div className="mt-3">
+              <Paragraph
+                copyable={{
+                  text: url,
+                }}
+              >
+                Share Link
+              </Paragraph>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}
+
+export default ShareBtn

--- a/src/components/Course/AnnouncementList/index.js
+++ b/src/components/Course/AnnouncementList/index.js
@@ -43,7 +43,7 @@ const CourseAnnouncementList = ({ announcements }) => {
           )}
         </div>
       </div>
-      <div className={`card-body overflow-scroll ${!isExpanded ? 'announcement-card-body' : ''}`}>
+      <div className={`card-body overflow-y-scroll ${!isExpanded ? 'announcement-card-body' : ''}`}>
         {size(announcements) === 0 && <Empty />}
         {size(announcements) > 0 &&
           map(announcements, announcement => {

--- a/src/components/Course/CourseListingCard/index.js
+++ b/src/components/Course/CourseListingCard/index.js
@@ -24,7 +24,7 @@ const CourseListingCard = data => {
               &nbsp;&nbsp;COURSE
             </span>
           </div>
-          <div className="course-card-img-holder overflow-scroll">
+          <div className="course-card-img-holder overflow-hidden">
             <img
               className="course-card-img"
               alt="example"

--- a/src/components/Course/LessonComments/CommentGridItem/index.js
+++ b/src/components/Course/LessonComments/CommentGridItem/index.js
@@ -67,7 +67,11 @@ const CommentGridItem = ({ comment, user, isLoading, handleDelete, handleReport,
       </div>
       {!isAdmin && (
         <div className="col-auto align-self-start">
-          <Dropdown overlay={commentMenu()} trigger={['click']}>
+          <Dropdown
+            overlay={commentMenu()}
+            trigger={['click']}
+            overlayStyle={{ boxShadow: '2px 3px 5px 1px rgba(0, 0, 0, .1)' }}
+          >
             <Button type="text" size="large" icon={<MoreOutlined />} />
           </Dropdown>
         </div>

--- a/src/components/Mentorship/ListingDetails/MentorshipProfileHeader.js
+++ b/src/components/Mentorship/ListingDetails/MentorshipProfileHeader.js
@@ -1,25 +1,20 @@
 import React, { useState, useEffect } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import { Button, Modal, Typography } from 'antd'
+import { Button } from 'antd'
 import { size } from 'lodash'
-import { CheckSquareOutlined, QrcodeOutlined } from '@ant-design/icons'
-import QRCode from 'react-qr-code'
-import { FacebookIcon, FacebookShareButton } from 'react-share'
+import { CheckSquareOutlined } from '@ant-design/icons'
 import { useSelector } from 'react-redux'
 import BackBtn from 'components/Common/BackBtn'
 import { getAllStudentMentorshipApplications } from 'services/mentorship/applications'
 import { CONTRACT_PROGRESS_ENUM, MENTORSHIP_CONTRACT_APPROVAL } from 'constants/constants'
+import ShareBtn from 'components/Common/Social/ShareBtn'
 
 const MentorshipProfileHeader = () => {
   const { id } = useParams()
   const history = useHistory()
   const user = useSelector(state => state.user)
-  const [showQRCode, setShowQRCode] = useState(false)
   const [isSubscribed, setIsSubscribed] = useState(false)
 
-  const { Paragraph } = Typography
-
-  const shareUrl = `http://digi.dojo/mentorship/view/${id}`
   const title = `${user.firstName} is sharing a Digi Dojo mentorship listing with you!`
 
   const onAdd = e => {
@@ -51,24 +46,12 @@ const MentorshipProfileHeader = () => {
   }, [])
 
   return (
-    <div className="row justify-content-between ">
-      <div className="col-auto">
+    <div className="row pt-2 justify-content-between">
+      <div className="col-12 col-md-3 col-lg-2 mt-4 mt-md-0">
         <BackBtn />
       </div>
 
-      <div className="col-auto d-flex justify-content-center">
-        <FacebookShareButton className="mr-4" url={shareUrl} quote={title} hashtag="DigiDojo">
-          <FacebookIcon size={38} round />
-        </FacebookShareButton>
-
-        <Button
-          className="mr-4"
-          type="primary"
-          shape="round"
-          icon={<QrcodeOutlined />}
-          size="large"
-          onClick={() => setShowQRCode(true)}
-        />
+      <div className="col text-right mt-4 mt-md-0">
         <Button
           type="primary"
           size="large"
@@ -80,29 +63,14 @@ const MentorshipProfileHeader = () => {
           Apply for Mentorship
         </Button>
       </div>
-      <Modal
-        title="View QR"
-        visible={showQRCode}
-        cancelText="Close"
-        centered
-        okButtonProps={{ style: { display: 'none' } }}
-        onCancel={() => setShowQRCode(false)}
-      >
-        <div className="row mt-3">
-          <div className="col-12 text-center">
-            <QRCode value={`http://localhost:3000/mentorship/view/${id}`} />
-            <div className="mt-3">
-              <Paragraph
-                copyable={{
-                  text: `http://localhost:3000/mentorship/view/${id}`,
-                }}
-              >
-                Share Link
-              </Paragraph>
-            </div>
-          </div>
-        </div>
-      </Modal>
+      <div className="col-auto mt-4 mt-md-0">
+        <ShareBtn
+          quote={title}
+          url={`http://localhost:3000/student/mentorship/view/${id}`}
+          btnType="primary"
+          btnShape="round"
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/Profile/PersonalInformationCard/index.js
+++ b/src/components/Profile/PersonalInformationCard/index.js
@@ -19,7 +19,7 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
   const [showEditInformation, setShowEditInformation] = useState(false)
   const [showDPModal, setShowDPModal] = useState(false)
 
-  const title = `${user.firstName || 'Anonymous Pigeon'} is sharing his Digi Dojo profile with you!`
+  const title = `${user.firstName || 'Anonymous'} is sharing their Digi Dojo profile with you!`
 
   const onUpdateProfile = values => {
     const formValues = {

--- a/src/components/Profile/PersonalInformationCard/index.js
+++ b/src/components/Profile/PersonalInformationCard/index.js
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux'
 import { Button, Descriptions, Form, Input, Modal, Typography, Upload, message } from 'antd'
 import QRCode from 'react-qr-code'
 import { isNil } from 'lodash'
-import { FacebookShareButton, FacebookIcon, LinkedinShareButton, LinkedinIcon } from 'react-share'
 import { QrcodeOutlined, CameraOutlined, PlusOutlined } from '@ant-design/icons'
 import actions from 'redux/user/actions'
 import { USER_TYPE_ENUM } from 'constants/constants'
 import moment from 'moment'
 import { NO_DP_TO_REMOVE } from 'constants/notifications'
+import ShareBtn from 'components/Common/Social/ShareBtn'
 
 const onFinishFailed = errorInfo => {
   console.log('Failed:', errorInfo)
@@ -23,7 +23,6 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
   const [showQRCode, setShowQRCode] = useState(false)
   const [showDPModal, setShowDPModal] = useState(false)
 
-  const shareUrl = `http://digi.dojo/profile/${user.accountId}`
   const title = `${user.firstName} is sharing his Digi Dojo profile with you!`
 
   const onUpdateProfile = values => {
@@ -175,12 +174,14 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
               onClick={() => setShowQRCode(true)}
             />
             <div>
-              <FacebookShareButton className="ml-3" url={shareUrl} quote={title} hashtag="DigiDojo">
-                <FacebookIcon size={32} round />
-              </FacebookShareButton>
-              <LinkedinShareButton url={shareUrl} className="ml-2">
-                <LinkedinIcon size={32} round />
-              </LinkedinShareButton>
+              <ShareBtn
+                quote={title}
+                url={`http://localhost:3000/social/profile/${user.accountId}`}
+                btnType="default"
+                btnSize="middle"
+                btnShape="round"
+                btnClassName="ml-2"
+              />
             </div>
           </div>
           <div className="col-12">

--- a/src/components/Profile/PersonalInformationCard/index.js
+++ b/src/components/Profile/PersonalInformationCard/index.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { Button, Descriptions, Form, Input, Modal, Typography, Upload, message } from 'antd'
-import QRCode from 'react-qr-code'
+import { Button, Descriptions, Form, Input, Modal, Upload, message } from 'antd'
 import { isNil } from 'lodash'
-import { QrcodeOutlined, CameraOutlined, PlusOutlined } from '@ant-design/icons'
+import { CameraOutlined, PlusOutlined } from '@ant-design/icons'
 import actions from 'redux/user/actions'
 import { USER_TYPE_ENUM } from 'constants/constants'
 import moment from 'moment'
@@ -15,15 +14,12 @@ const onFinishFailed = errorInfo => {
 }
 
 const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
-  const { Paragraph } = Typography
-
   const dispatch = useDispatch()
 
   const [showEditInformation, setShowEditInformation] = useState(false)
-  const [showQRCode, setShowQRCode] = useState(false)
   const [showDPModal, setShowDPModal] = useState(false)
 
-  const title = `${user.firstName} is sharing his Digi Dojo profile with you!`
+  const title = `${user.firstName || 'Anonymous Pigeon'} is sharing his Digi Dojo profile with you!`
 
   const onUpdateProfile = values => {
     const formValues = {
@@ -163,16 +159,10 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
                 size="middle"
                 icon={<CameraOutlined />}
                 onClick={() => setShowDPModal(true)}
-              />
+              >
+                Upload
+              </Button>
             )}
-            <Button
-              className="ml-2"
-              type="primary"
-              shape="round"
-              icon={<QrcodeOutlined />}
-              size="middle"
-              onClick={() => setShowQRCode(true)}
-            />
             <div>
               <ShareBtn
                 quote={title}
@@ -319,32 +309,6 @@ const PersonalInformationCard = ({ user, showEditTools, isAdmin }) => {
               </div>
             </Form>
           </Modal>
-          <Modal
-            title="View QR"
-            visible={showQRCode}
-            cancelText="Close"
-            centered
-            okButtonProps={{ style: { display: 'none' } }}
-            onCancel={() => setShowQRCode(false)}
-          >
-            <div className="row mt-3">
-              <div className="col-12 text-center">
-                <QRCode value={`http://localhost:3000/social/profile/${user.accountId}`} />
-                <div className="mt-3">
-                  <Paragraph
-                    copyable={{
-                      text: isAdmin
-                        ? `http://localhost:3000/admin/social/profile/${user.accountId}`
-                        : `http://localhost:3000/social/profile/${user.accountId}`,
-                    }}
-                  >
-                    Share Link
-                  </Paragraph>
-                </div>
-              </div>
-            </div>
-          </Modal>
-
           <Modal
             title="Upload Display Picture"
             visible={showDPModal}

--- a/src/components/UserActionGroup/UserMenu/index.js
+++ b/src/components/UserActionGroup/UserMenu/index.js
@@ -87,7 +87,9 @@ const UserMenu = () => {
           <span className="mb-5">Welcome,</span>
         </div>
         <div className="mt-2 col-12 font-size-18">
-          <span className="font-weight-bold">{`${firstName} ${lastName} [${username}]`}</span>
+          <span className="font-weight-bold">
+            {`${firstName || 'Anonymous'} ${lastName || 'Pigeon'} [${username}]`}
+          </span>
         </div>
       </div>
       <Menu.Divider />

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -7,7 +7,7 @@ import {
   DIRECTION,
   USER_TYPE_ENUM,
 } from 'constants/constants'
-import { filter, isNil, map, size } from 'lodash'
+import { filter, isEmpty, isNil, map, size } from 'lodash'
 import moment from 'moment'
 
 export const formatTime = dateTime => {
@@ -281,7 +281,9 @@ export const isFollowing = (followingList, accountId) => {
 }
 
 export const sendToSocialProfile = (history, user, accountId) => {
-  if (user.userType === USER_TYPE_ENUM.SENSEI) history.push(`/sensei/social/profile/${accountId}`)
+  if (isEmpty(user.userType)) history.replace(`/auth/login`)
+  else if (user.userType === USER_TYPE_ENUM.SENSEI)
+    history.push(`/sensei/social/profile/${accountId}`)
   else if (user.userType === USER_TYPE_ENUM.STUDENT) history.push(`/social/profile/${accountId}`)
 }
 

--- a/src/global.css
+++ b/src/global.css
@@ -15,7 +15,13 @@
 }
 
 .course-card-img-holder {
-  max-height: 150px;
+  height: 150px;
+  background-color: white;
+}
+
+.course-card-img-max {
+  max-height: 400px;
+  background-color: white;
 }
 
 .course-img-banner-holder {
@@ -41,10 +47,6 @@
   max-height: 100%;
   overflow-y: scroll;
   overflow-x: hidden;
-}
-
-.invisible-btn:hover {
-  cursor: pointer;
 }
 
 .lesson-list-card {

--- a/src/layouts/Public/index.js
+++ b/src/layouts/Public/index.js
@@ -1,16 +1,19 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { withRouter, Redirect } from 'react-router-dom'
+import { withRouter, Redirect, useLocation } from 'react-router-dom'
 import CustomLayout from 'components/CustomLayout'
 import { USER_TYPE_ENUM } from 'constants/constants'
 
 const PublicLayout = ({ children }) => {
   const user = useSelector(state => state.user)
+  const { pathname } = useLocation()
+
   if (user.authorized) {
     switch (user.userType) {
       case USER_TYPE_ENUM.ADMIN:
         return <Redirect to="/admin" />
       case USER_TYPE_ENUM.SENSEI:
+        if (pathname.includes('/social/profile/')) return <Redirect to={`/sensei${pathname}`} />
         return <Redirect to="/sensei" />
       default:
         break

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -144,7 +144,7 @@ const ViewCourseDetailsPublic = () => {
                 </div>
                 <div className="col-auto">
                   <ShareBtn
-                    quote={`${user.firstName || 'Anonymous Pigeon'} is sharing this course: [${
+                    quote={`${user.firstName || 'Anonymous'} is sharing this course: [${
                       currentCourse.title
                     }] with you!`}
                     url={`http://localhost:3000/courses/${currentCourse.courseId}`}

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useParams } from 'react-router-dom'
-import { Button, Descriptions, List, Rate, Typography } from 'antd'
+import { Button, Descriptions, Image, List, Rate, Typography } from 'antd'
 import { Helmet } from 'react-helmet'
 import { getCourseById } from 'services/courses'
 import { indexOf, isEmpty, isNil, map, random } from 'lodash'
@@ -10,6 +10,7 @@ import { ADD_TO_CART, CREATOR_INFO, CURRENT_PRICE, DIGI_DOJO, NA } from 'constan
 import { formatTime, sendToSocialProfile } from 'components/utils'
 import SocialFollowBtn from 'components/Common/Social/FollowBtn'
 import { USER_TYPE_ENUM } from 'constants/constants'
+import ShareBtn from 'components/Common/Social/ShareBtn'
 
 const ViewCourseDetailsPublic = () => {
   const dispatch = useDispatch()
@@ -114,10 +115,9 @@ const ViewCourseDetailsPublic = () => {
 
         <div className="col-12 col-lg-4 order-1 order-lg-12">
           <div className="card">
-            <div className="course-card-img-holder overflow-scroll">
-              <img
+            <div className="course-card-img-max overflow-hidden">
+              <Image
                 className="course-card-img"
-                alt="example"
                 src={
                   !isNil(currentCourse.imgUrl)
                     ? currentCourse.imgUrl
@@ -130,15 +130,28 @@ const ViewCourseDetailsPublic = () => {
               <h2 className="font-weight-bold">
                 ${parseFloat(currentCourse.priceAmount).toFixed(2)}
               </h2>
-              <Button
-                block
-                type="primary"
-                size="large"
-                className="mt-4"
-                onClick={() => addToCart()}
-              >
-                {ADD_TO_CART}
-              </Button>
+              <div className="row align-items-center">
+                <div className="col pr-0">
+                  <Button
+                    block
+                    type="primary"
+                    size="large"
+                    className="mt-3"
+                    onClick={() => addToCart()}
+                  >
+                    {ADD_TO_CART}
+                  </Button>
+                </div>
+                <div className="col-auto">
+                  <ShareBtn
+                    quote={`${user.firstName || 'Anonymous Pigeon'} is sharing this course: [${
+                      currentCourse.title
+                    }] with you!`}
+                    url={`http://localhost:3000/courses/${currentCourse.courseId}`}
+                    btnClassName="mt-3"
+                  />
+                </div>
+              </div>
               <hr className="mt-4" />
               <div className="mt-4">
                 <small className="text-uppercase text-secondary">{CREATOR_INFO}</small>
@@ -158,15 +171,17 @@ const ViewCourseDetailsPublic = () => {
                 </div>
                 <div className="row">
                   <div className="col-12">
-                    <a
-                      className="h3 font-weight-bold"
-                      href="#"
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      className="h3 font-weight-bold clickable defocus-btn"
                       onClick={() => sendToSocialProfile(history, user, currentCourse.accountId)}
+                      onKeyDown={e => e.preventDefault()}
                     >
                       {`${isNil(currentSensei.firstName) ? 'Anonymous' : currentSensei.firstName} ${
                         isNil(currentSensei.lastName) ? 'Pigeon' : currentSensei.lastName
                       }`}
-                    </a>
+                    </div>
                   </div>
                   <div className="col-12 mt-2">
                     <div className="h5 text-uppercase">


### PR DESCRIPTION
# Changelog:

replace `invisible-btn` with `clickable` from KT, removed `invisible-btn` for consistency
add common share btn, add to courses/mentorship/personal information pages
fix course image display inconsistencies
fix dropdown showing null null for name
add shadow to dropdown menu so it looks nicer
fix sendToSocialProfile not working when user is not logged in
fix redirect from /social/profile links to /sensei/social/profile to allow for Sharing of social profile via a single link without containing `/sensei`
TODO: Share btn to include functionality for sharing posts, add View Course as student (for sensei)
Prolly need to refine the share btn a bit more

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
<img width="333" alt="image" src="https://user-images.githubusercontent.com/43084055/113934187-04b4be80-9828-11eb-95d0-798600521203.png">
<img width="301" alt="image" src="https://user-images.githubusercontent.com/43084055/113934206-08484580-9828-11eb-9665-54b3d1f587e0.png">
<img width="843" alt="image" src="https://user-images.githubusercontent.com/43084055/113934219-0c746300-9828-11eb-978b-e6230aa42417.png">
<img width="325" alt="image" src="https://user-images.githubusercontent.com/43084055/113934251-19915200-9828-11eb-8f24-e310ab5a92d0.png">
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/43084055/113934577-8573ba80-9828-11eb-8e43-820262e8bcc2.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/43084055/113935184-05018980-9829-11eb-8c1c-398239d2b0eb.png">

