### PR TITLE
Allow remembering of direct path and auto redirect on login

### DIFF
--- a/src/components/Common/Social/FollowerRequestList/index.js
+++ b/src/components/Common/Social/FollowerRequestList/index.js
@@ -5,12 +5,11 @@ import { Avatar, Button, Space } from 'antd'
 import PaginationWrapper from 'components/Common/Pagination'
 import { getUserFullName, initPageItems, sendToSocialProfile } from 'components/utils'
 import { isNil, map, size } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { SOCIAL_ACTIONS } from 'constants/constants'
 
 const FollowerRequestList = ({ pendingFollowerList, setShowSocialModal }) => {
   const history = useHistory()
-  const user = useSelector(state => state.user)
   const dispatch = useDispatch()
 
   const [isLoading, setIsLoading] = useState(false)
@@ -30,7 +29,7 @@ const FollowerRequestList = ({ pendingFollowerList, setShowSocialModal }) => {
   }, [pendingFollowerList])
 
   const socialProfileOverride = accountId => {
-    sendToSocialProfile(history, user, accountId)
+    sendToSocialProfile(history, accountId)
     if (!isNil(setShowSocialModal)) setShowSocialModal(false)
   }
 

--- a/src/components/Common/Social/FollowingList/index.js
+++ b/src/components/Common/Social/FollowingList/index.js
@@ -42,7 +42,7 @@ const SocialFollowingList = ({ followingList, isFollowingList, isOwnList, setSho
   }, [followingList])
 
   const socialProfileOverride = accountId => {
-    sendToSocialProfile(history, user, accountId)
+    sendToSocialProfile(history, accountId)
     if (!isNil(setShowSocialModal)) setShowSocialModal(false)
   }
 

--- a/src/components/Common/Social/PostComment/Item/index.js
+++ b/src/components/Common/Social/PostComment/Item/index.js
@@ -74,7 +74,7 @@ const PostCommentItem = ({ comment, isLoading, showCommentModalWithOptions }) =>
               role="button"
               tabIndex={0}
               className="clickable font-weight-bold"
-              onClick={() => sendToSocialProfile(history, user, comment.User?.accountId)}
+              onClick={() => sendToSocialProfile(history, comment.User?.accountId)}
               onKeyDown={e => e.preventDefault()}
             >
               {getUserFullName(comment.User)}

--- a/src/components/Common/Social/PostList/Item/index.js
+++ b/src/components/Common/Social/PostList/Item/index.js
@@ -88,7 +88,7 @@ const SocialPostListItem = ({ user, post, isLoading, showPostModalWithOptions, b
                 role="button"
                 tabIndex={0}
                 className="clickable font-weight-bold font-size-18"
-                onClick={() => sendToSocialProfile(history, user, post.User?.accountId)}
+                onClick={() => sendToSocialProfile(history, post.User?.accountId)}
                 onKeyDown={e => e.preventDefault()}
               >
                 {getUserFullName(post.User)}

--- a/src/components/Common/Social/UsersBlockedList/index.js
+++ b/src/components/Common/Social/UsersBlockedList/index.js
@@ -10,14 +10,13 @@ import {
   showNotification,
 } from 'components/utils'
 import { isNil, map, size } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { unblockUser } from 'services/social'
 import { SUCCESS, USER_UNBLOCKED } from 'constants/notifications'
 
 const UsersBlockedList = ({ usersBlockedList, setShowSocialModal }) => {
   const history = useHistory()
   const dispatch = useDispatch()
-  const user = useSelector(state => state.user)
 
   const [isLoading, setIsLoading] = useState(false)
   const [paginatedBlocks, setPaginatedBlocks] = useState([])
@@ -36,7 +35,7 @@ const UsersBlockedList = ({ usersBlockedList, setShowSocialModal }) => {
   }, [usersBlockedList])
 
   const socialProfileOverride = accountId => {
-    sendToSocialProfile(history, user, accountId)
+    sendToSocialProfile(history, accountId)
     if (!isNil(setShowSocialModal)) setShowSocialModal(false)
   }
 

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,13 +1,8 @@
 import React from 'react'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { notification, message, Button } from 'antd'
-import {
-  DEFAULT_ITEMS_PER_PAGE,
-  DEFAULT_TIMEOUT,
-  DIRECTION,
-  USER_TYPE_ENUM,
-} from 'constants/constants'
-import { filter, isEmpty, isNil, map, size } from 'lodash'
+import { DEFAULT_ITEMS_PER_PAGE, DEFAULT_TIMEOUT, DIRECTION } from 'constants/constants'
+import { filter, isNil, map, size } from 'lodash'
 import moment from 'moment'
 
 export const formatTime = dateTime => {
@@ -288,11 +283,8 @@ export const isFollowing = (followingList, accountId) => {
   return size(followingList.filter(following => following.followingId === accountId)) === 1
 }
 
-export const sendToSocialProfile = (history, user, accountId) => {
-  if (isEmpty(user.userType)) history.replace(`/auth/login`)
-  else if (user.userType === USER_TYPE_ENUM.SENSEI)
-    history.push(`/sensei/social/profile/${accountId}`)
-  else if (user.userType === USER_TYPE_ENUM.STUDENT) history.push(`/social/profile/${accountId}`)
+export const sendToSocialProfile = (history, accountId) => {
+  history.push(`/social/profile/${accountId}`)
 }
 
 export const initPageItems = (

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -23,6 +23,7 @@ let previousPath = ''
 
 const Layout = ({ children, location: { pathname, search } }) => {
   const user = useSelector(state => state.user)
+  const settings = useSelector(state => state.settings)
   // NProgress & ScrollTop Management
   const currentPath = pathname + search
   if (currentPath !== previousPath) {
@@ -83,9 +84,15 @@ const Layout = ({ children, location: { pathname, search } }) => {
       if (
         isUserAuthorized ||
         (!isUserAuthorized &&
-          (/^\/sensei(?=\/|$)/i.test(pathname) || /^\/student(?=\/|$)/i.test(pathname)))
-      )
+          (/^\/sensei(?=\/|$)/i.test(pathname) ||
+            /^\/student(?=\/|$)/i.test(pathname) ||
+            /^\/social(?=\/|$)/i.test(pathname)))
+      ) {
+        if (['sensei', 'student', 'social'].some(path => pathname.includes(path))) {
+          settings.rememberPath = pathname
+        }
         return <Redirect to="/auth/login" />
+      }
       if (!isUserAuthorized && /^\/admin(?=\/|$)/i.test(pathname))
         return <Redirect to="/auth/admin" />
     }

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -88,9 +88,7 @@ const Layout = ({ children, location: { pathname, search } }) => {
             /^\/student(?=\/|$)/i.test(pathname) ||
             /^\/social(?=\/|$)/i.test(pathname)))
       ) {
-        if (['sensei', 'student', 'social'].some(path => pathname.includes(path))) {
-          settings.rememberPath = pathname
-        }
+        settings.rememberPath = pathname
         return <Redirect to="/auth/login" />
       }
       if (!isUserAuthorized && /^\/admin(?=\/|$)/i.test(pathname))

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -188,7 +188,7 @@ const ViewCourseDetailsPublic = () => {
                       role="button"
                       tabIndex={0}
                       className="h3 font-weight-bold clickable defocus-btn"
-                      onClick={() => sendToSocialProfile(history, user, currentCourse.accountId)}
+                      onClick={() => sendToSocialProfile(history, currentCourse.accountId)}
                       onKeyDown={e => e.preventDefault()}
                     >
                       {getUserFullName(currentSensei)}

--- a/src/pages/courses/view/index.js
+++ b/src/pages/courses/view/index.js
@@ -44,7 +44,15 @@ const ViewCourseDetailsPublic = () => {
         type: 'cart/ADD_COURSE_TO_CART',
         payload: { courseId: id },
       })
-    else history.push('/auth/login')
+    else {
+      dispatch({
+        type: 'settings/SET_STATE',
+        payload: {
+          rememberPath: `/courses/${id}`,
+        },
+      })
+      history.push('/auth/login')
+    }
   }
 
   return (

--- a/src/redux/settings/reducers.js
+++ b/src/redux/settings/reducers.js
@@ -37,6 +37,7 @@ const initialState = {
     isSquaredBorders: false,
     isBorderless: false,
     isDevMode: true,
+    rememberPath: '',
   }),
 }
 

--- a/src/redux/user/sagas.js
+++ b/src/redux/user/sagas.js
@@ -101,20 +101,31 @@ export function* LOGIN({ payload }) {
       },
     })
     yield call(jwt.updateLocalUserData, currentUser)
-    switch (currentUser.userType) {
-      case USER_TYPE_ENUM.ADMIN:
-        yield history.push('/admin')
-        break
-      case USER_TYPE_ENUM.SENSEI:
-        yield history.push('/sensei')
-        break
-      case USER_TYPE_ENUM.STUDENT:
-        yield history.push('/')
-        break
-      default:
-        yield history.push('/')
-        break
+    const settings = yield select(selectors.settings)
+    if (!isEmpty(settings.rememberPath)) {
+      yield history.push(settings.rememberPath)
+    } else {
+      switch (currentUser.userType) {
+        case USER_TYPE_ENUM.ADMIN:
+          yield history.push('/admin')
+          break
+        case USER_TYPE_ENUM.SENSEI:
+          yield history.push('/sensei')
+          break
+        case USER_TYPE_ENUM.STUDENT:
+          yield history.push('/')
+          break
+        default:
+          yield history.push('/')
+          break
+      }
     }
+    yield putResolve({
+      type: 'settings/SET_STATE',
+      payload: {
+        rememberPath: '',
+      },
+    })
     if (isNil(currentUser.firstName)) currentUser.firstName = 'Anonymous'
     if (isNil(currentUser.lastName)) currentUser.lastName = 'Pigeon'
     notification.success({
@@ -210,6 +221,12 @@ export function* LOGOUT() {
   })
   yield putResolve({
     type: 'menu/GET_DATA',
+  })
+  yield putResolve({
+    type: 'settings/SET_STATE',
+    payload: {
+      rememberPath: '',
+    },
   })
   yield history.push('/')
 }


### PR DESCRIPTION
# Description

add ability to remember paths and redirect automatically after login (if valid)
only urls with 'sensei'/'student'/'social' inside the url will be redirected
removed user object check from sendToSocialProfile as it is no longer required

# Changelog:

see commit log

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense
