### PR TITLE
Zhng CountIconWidgetGroup

### DIFF
--- a/src/components/Admin/ManagementSkeleton/index.js
+++ b/src/components/Admin/ManagementSkeleton/index.js
@@ -37,6 +37,9 @@ const ManagementSkeleton = ({
         handleAcceptedWidgetOnClick={handleAcceptedWidgetOnClick}
         handlePendingWidgetOnClick={handlePendingWidgetOnClick}
         handleRejectedWidgetOnClick={handleRejectedWidgetOnClick}
+        pendingPrefix="Pending"
+        acceptedPrefix="Accepted"
+        rejectedPrefix="Rejected"
       />
 
       <div className="row mt-2">

--- a/src/components/Admin/UsersManagement/UserCountIconWidget/index.js
+++ b/src/components/Admin/UsersManagement/UserCountIconWidget/index.js
@@ -75,6 +75,9 @@ const UserCountIconWidget = ({
         handleAcceptedWidgetOnClick={() => setTableData('accepted')}
         handlePendingWidgetOnClick={() => setTableData('pending')}
         handleRejectedWidgetOnClick={() => setTableData('rejected')}
+        pendingPrefix="Pending"
+        acceptedPrefix="Accepted"
+        rejectedPrefix="Rejected"
       />
     )
   }

--- a/src/components/Common/CountIconWidgetGroup/index.js
+++ b/src/components/Common/CountIconWidgetGroup/index.js
@@ -12,6 +12,9 @@ const CountIconWidgetGroup = ({
   handlePendingWidgetOnClick,
   handleRejectedWidgetOnClick,
   noClick,
+  pendingPrefix,
+  acceptedPrefix,
+  rejectedPrefix,
 }) => {
   const getClassName = filterName => {
     if (noClick) return null
@@ -23,7 +26,7 @@ const CountIconWidgetGroup = ({
     <div className="row mt-4">
       <div className="col-12 col-md-4">
         <CountIconWidget
-          title={`Pending ${objectType}`}
+          title={`${pendingPrefix} ${objectType}`}
           className={getClassName('pending')}
           count={numPending}
           icon={<ExceptionOutlined />}
@@ -34,7 +37,7 @@ const CountIconWidgetGroup = ({
 
       <div className="col-6 col-md-4">
         <CountIconWidget
-          title={`Accepted ${objectType}`}
+          title={`${acceptedPrefix} ${objectType}`}
           className={getClassName('accepted')}
           count={numAccepted}
           icon={<CheckOutlined />}
@@ -45,7 +48,7 @@ const CountIconWidgetGroup = ({
 
       <div className="col-6 col-md-4">
         <CountIconWidget
-          title={`Rejected ${objectType}`}
+          title={`${rejectedPrefix} ${objectType}`}
           className={getClassName('rejected')}
           count={numRejected}
           icon={<CloseOutlined />}

--- a/src/components/Common/CountIconWidgetGroup/index.js
+++ b/src/components/Common/CountIconWidgetGroup/index.js
@@ -11,13 +11,20 @@ const CountIconWidgetGroup = ({
   handleAcceptedWidgetOnClick,
   handlePendingWidgetOnClick,
   handleRejectedWidgetOnClick,
+  noClick,
 }) => {
+  const getClassName = filterName => {
+    if (noClick) return null
+    if (currentFilter === filterName) return 'btn btn-light'
+    return 'btn'
+  }
+
   return (
     <div className="row mt-4">
       <div className="col-12 col-md-4">
         <CountIconWidget
           title={`Pending ${objectType}`}
-          className={`${currentFilter === 'pending' ? 'btn btn-light' : 'btn'}`}
+          className={getClassName('pending')}
           count={numPending}
           icon={<ExceptionOutlined />}
           onClick={handlePendingWidgetOnClick}
@@ -28,7 +35,7 @@ const CountIconWidgetGroup = ({
       <div className="col-6 col-md-4">
         <CountIconWidget
           title={`Accepted ${objectType}`}
-          className={`${currentFilter === 'accepted' ? 'btn btn-light' : 'btn'}`}
+          className={getClassName('accepted')}
           count={numAccepted}
           icon={<CheckOutlined />}
           onClick={handleAcceptedWidgetOnClick}
@@ -39,7 +46,7 @@ const CountIconWidgetGroup = ({
       <div className="col-6 col-md-4">
         <CountIconWidget
           title={`Rejected ${objectType}`}
-          className={`${currentFilter === 'rejected' ? 'btn btn-light' : 'btn'}`}
+          className={getClassName('rejected')}
           count={numRejected}
           icon={<CloseOutlined />}
           onClick={handleRejectedWidgetOnClick}

--- a/src/pages/sensei/courses/index.js
+++ b/src/pages/sensei/courses/index.js
@@ -219,6 +219,9 @@ const SenseiCourses = () => {
         numPending={numPendingCourses}
         numRejected={numRejectedCourses}
         noClick
+        pendingPrefix="Draft"
+        acceptedPrefix="Accepted"
+        rejectedPrefix="Rejected"
       />
       <div className="row align-items-center">
         <div className="col-12 mt-2 text-center text-md-right">

--- a/src/pages/sensei/courses/index.js
+++ b/src/pages/sensei/courses/index.js
@@ -218,6 +218,7 @@ const SenseiCourses = () => {
         numAccepted={numAcceptedCourses}
         numPending={numPendingCourses}
         numRejected={numRejectedCourses}
+        noClick
       />
       <div className="row align-items-center">
         <div className="col-12 mt-2 text-center text-md-right">


### PR DESCRIPTION
# Changelog:

Enable CountIconWidgetGroup to be more flexible by allowing prefix and noClick customisations

Was considering making the entire title changeable, but ehhhh we can do that next time if its needed.

Usage example:
![image](https://user-images.githubusercontent.com/43084055/114263153-81a58b00-9a16-11eb-87cf-94664a44b51c.png)


![image](https://user-images.githubusercontent.com/43084055/114263162-8d914d00-9a16-11eb-8d80-ae6dbe42ea49.png)


## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
