### PR TITLE
fix error when displaying StatusTag

### DIFF
--- a/src/components/Admin/Mentorship/index.js
+++ b/src/components/Admin/Mentorship/index.js
@@ -485,10 +485,7 @@ const Mentorship = () => {
             </Descriptions.Item>
             <Descriptions.Item label="Progress">
               {applicationDetails.progress ? (
-                <StatusTag
-                  data={{ progress: applicationDetails.progress }}
-                  type="CONTRACT_PROGRESS_ENUM"
-                />
+                <StatusTag data={applicationDetails.progress} type="CONTRACT_PROGRESS_ENUM" />
               ) : (
                 '-'
               )}
@@ -496,7 +493,7 @@ const Mentorship = () => {
             <Descriptions.Item label="Sensei Approval">
               {applicationDetails.senseiApproval ? (
                 <StatusTag
-                  data={{ senseiApproval: applicationDetails.senseiApproval }}
+                  data={applicationDetails.senseiApproval}
                   type="MENTORSHIP_CONTRACT_APPROVAL"
                 />
               ) : (
@@ -545,10 +542,7 @@ const Mentorship = () => {
             </Descriptions.Item>
             <Descriptions.Item label="Progress">
               {contractDetails.progress ? (
-                <StatusTag
-                  data={{ progress: contractDetails.progress }}
-                  type="CONTRACT_PROGRESS_ENUM"
-                />
+                <StatusTag data={contractDetails.progress} type="CONTRACT_PROGRESS_ENUM" />
               ) : (
                 '-'
               )}
@@ -556,7 +550,7 @@ const Mentorship = () => {
             <Descriptions.Item label="Sensei Approval">
               {contractDetails.senseiApproval ? (
                 <StatusTag
-                  data={{ senseiApproval: contractDetails.senseiApproval }}
+                  data={contractDetails.senseiApproval}
                   type="MENTORSHIP_CONTRACT_APPROVAL"
                 />
               ) : (


### PR DESCRIPTION
# Changelog:

fix error passing in data object instead of data literal as the StatusTag side didn't account for {{ }} type of objects (only data.data) instead of (data.data.senseiApproval) for example

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):

# Before Fix:
![image](https://user-images.githubusercontent.com/43084055/114267642-862a6d80-9a2f-11eb-9f10-305ed45576af.png)

# After Fix:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/43084055/114267664-a2c6a580-9a2f-11eb-93d7-407847b260ad.png">

