### PR TITLE
Bugfix: multiple mentorship contracts in modal body and add scroll

### DIFF
--- a/src/pages/sensei/mentees/index.js
+++ b/src/pages/sensei/mentees/index.js
@@ -112,36 +112,6 @@ const MenteeOverviewPage = () => {
     </div>
   )
 
-  const MentorshipContractModalBody = contracts => {
-    return map(contracts, contract => (
-      <div key={contract[0].mentorshipContractId} className="card">
-        <div className="card-body">
-          <p>
-            <strong>Progress: </strong>
-            <StatusTag data={contract[0].progress} type="CONTRACT_PROGRESS_ENUM" />
-          </p>
-          <p>
-            <strong>Approval Status: </strong>
-            <StatusTag data={contract[0].senseiApproval} type="MENTORSHIP_CONTRACT_APPROVAL" />
-          </p>
-          <p>
-            <strong>Listing Id: </strong>
-            {contract[0].mentorshipListingId}
-          </p>
-          <p>
-            <strong>Contract Id: </strong>
-            {contract[0].mentorshipContractId}
-          </p>
-          {contract[0].progress === CONTRACT_PROGRESS_ENUM.COMPLETED &&
-            showAddTestimonialButton(contract[0].accountId, contract[0].mentorshipListingId)}
-        </div>
-        <div className="card-footer pb-0 pr-0">
-          <p className="text-muted">Created At: {formatTime(contract[0].createdAt)}</p>
-        </div>
-      </div>
-    ))
-  }
-
   return (
     <Skeleton active loading={isLoading}>
       <div className="card">
@@ -159,8 +129,35 @@ const MenteeOverviewPage = () => {
         centered
         okButtonProps={{ style: { display: 'none' } }}
         onCancel={() => setShowMentorshipContractModal(false)}
+        bodyStyle={{ height: 500, overflow: 'scroll' }}
       >
-        <MentorshipContractModalBody contract={studentMentorshipContract} />
+        {map(studentMentorshipContract, contract => (
+          <div key={contract.mentorshipContractId} className="card">
+            <div className="card-body">
+              <p>
+                <strong>Progress: </strong>
+                <StatusTag data={contract.progress} type="CONTRACT_PROGRESS_ENUM" />
+              </p>
+              <p>
+                <strong>Approval Status: </strong>
+                <StatusTag data={contract.senseiApproval} type="MENTORSHIP_CONTRACT_APPROVAL" />
+              </p>
+              <p>
+                <strong>Listing Id: </strong>
+                {contract.mentorshipListingId}
+              </p>
+              <p>
+                <strong>Contract Id: </strong>
+                {contract.mentorshipContractId}
+              </p>
+              {contract.progress === CONTRACT_PROGRESS_ENUM.COMPLETED &&
+                showAddTestimonialButton(contract.accountId, contract.mentorshipListingId)}
+            </div>
+            <div className="card-footer pb-0 pr-0">
+              <p className="text-muted">Created At: {formatTime(contract.createdAt)}</p>
+            </div>
+          </div>
+        ))}
       </Modal>
     </Skeleton>
   )


### PR DESCRIPTION
# Bug
- if there were multiple mentorship contracts it would only show the 1st one cos of the previously implemented contract[0]

# Changelog:
- brought out the code to the modal level to reduce the amount of nesting for contract (esp when accessing it to display the contents)
- add height and scroll style prop to modal


## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
![Screenshot 2021-04-11 at 10 18 55 PM](https://user-images.githubusercontent.com/41737751/114307879-37a2cf00-9b14-11eb-80cd-842fb0053609.png)
