### PR TITLE
B.5.2 view a Sensei's withdrawal request 

### DIFF
--- a/src/pages/admin/withdrawals/index.js
+++ b/src/pages/admin/withdrawals/index.js
@@ -13,9 +13,11 @@ import {
 import { WITHDRAWALS, WITHDRAWAL_MGT } from 'constants/text'
 import { filter, isNil, size } from 'lodash'
 import React, { useEffect, useState } from 'react'
+import { useHistory } from 'react-router-dom'
 import { approveWithdrawalRequest, rejectWithdrawalRequest, viewBillings } from 'services/wallet'
 
 const WithdrawalManagement = () => {
+  const history = useHistory()
   const [currentTableData, setCurrentTableData] = useState([])
   const [currentFilter, setCurrentFilter] = useState('all')
 
@@ -53,6 +55,11 @@ const WithdrawalManagement = () => {
     } else {
       showNotification('error', ERROR, APPROVE_WITHDRAWAL_REQ_ERR)
     }
+  }
+
+  const viewWithdrawalRequestBilling = id => {
+    const path = `/admin/billing/view/${id}`
+    history.push(path)
   }
 
   const getBillings = async () => {
@@ -157,7 +164,7 @@ const WithdrawalManagement = () => {
             size="large"
             icon={<InfoCircleOutlined />}
             onClick={() => {
-              console.log('record is ', record)
+              viewWithdrawalRequestBilling(record.billingId)
             }}
           />
           <Button


### PR DESCRIPTION
# Feature

Use Case: B.5.2 View a Sensei's withdrawal request
Feature: Payment Management

# Changelog:
- add function to redirect to view billing page

note: this is essentially the same as view a billing
## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):

<img width="1280" alt="Screenshot 2021-04-14 at 11 03 15 AM" src="https://user-images.githubusercontent.com/41737751/114648520-95503a80-9d11-11eb-8097-3b6cf49559ed.png">

_after clicking on the Info Icon, you go to the billing page to view the details of the withdrawal request_
<img width="1280" alt="Screenshot 2021-04-14 at 11 03 29 AM" src="https://user-images.githubusercontent.com/41737751/114648513-91241d00-9d11-11eb-98fa-89ecd77c9af2.png">
