### PR TITLE
sensei menu bar fix, course popconfirm fix, popconfirm btn fix

### DIFF
--- a/src/components/Sensei/Course/Announcements/index.js
+++ b/src/components/Sensei/Course/Announcements/index.js
@@ -130,6 +130,7 @@ const CourseAnnouncements = ({ currentCourse, isCourseCreated }) => {
           onConfirm={() => removeAnnouncement(record)}
           okText="Delete"
           okType="danger"
+          disabled={currentCourse.adminVerified === ADMIN_VERIFIED_ENUM.PENDING}
         >
           <Button
             type="danger"

--- a/src/components/Sensei/Wallet/index.js
+++ b/src/components/Sensei/Wallet/index.js
@@ -60,6 +60,7 @@ const SenseiWallet = ({
         okText="Withdraw"
         okType="primary"
         onCancel={handleCancel}
+        disabled={!isWithdrawable || isExistingWithdrawalRequest}
       >
         <Button
           block

--- a/src/components/UserGroupTopBar/index.js
+++ b/src/components/UserGroupTopBar/index.js
@@ -10,7 +10,7 @@ const UserGroupTopBar = () => {
   return (
     <div className={`${style.topbar}`}>
       <div className="row justify-content-end">
-        {user.userType !== USER_TYPE_ENUM.ADMIN && <Search />}
+        <div className="col-auto mr-2">{user.userType !== USER_TYPE_ENUM.ADMIN && <Search />}</div>
         <div className="col-auto pl-0">
           <UserActionGroup />
         </div>

--- a/src/pages/sensei/courses/create/index.js
+++ b/src/pages/sensei/courses/create/index.js
@@ -816,6 +816,7 @@ const SenseiCreateCourse = () => {
                           onConfirm={() => submitCourseForApproval()}
                           okText="Yes"
                           cancelText="No"
+                          disabled={!isCourseCreated}
                         >
                           <Button
                             disabled={!isCourseCreated}

--- a/src/pages/sensei/courses/create/index.js
+++ b/src/pages/sensei/courses/create/index.js
@@ -224,6 +224,7 @@ const SenseiCreateCourse = () => {
           onConfirm={() => handleDeleteLesson(record)}
           okText="Delete"
           okType="danger"
+          disabled={currentCourse.adminVerified === ADMIN_VERIFIED_ENUM.PENDING}
         >
           <Button
             type="danger"

--- a/src/pages/student/dashboard/mentorships/mentorship-subscription/index.js
+++ b/src/pages/student/dashboard/mentorships/mentorship-subscription/index.js
@@ -110,6 +110,7 @@ const MentorshipSubscriptionView = () => {
               okText="Yes"
               okType="danger"
               visible={showCancelPopconfirm}
+              disabled={!isCancellable}
             >
               <Button
                 shape="round"


### PR DESCRIPTION
fix sensei menu bar search box too near chat icon, fix course popcfm showing
disable other popconfirms based on the same disabled condition for their enclosed btns

# Changelog:

see files changed

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
