### PR TITLE
Fix course NaN bug

### DIFF
--- a/src/components/Student/Course/StudentCourseCard/index.js
+++ b/src/components/Student/Course/StudentCourseCard/index.js
@@ -19,7 +19,7 @@ const StudentCourseCard = data => {
 
   const getPercentageCompletion = () => {
     if (course.CourseContracts) {
-      if (size(course.CourseContracts) > 0 && !isNil(course.numLessons)) {
+      if (size(course.CourseContracts) > 0 && !isNil(course.numLessons) && course.numLessons > 0) {
         return ((size(course.CourseContracts[0].lessonProgress) / course.numLessons) * 100).toFixed(
           0,
         )


### PR DESCRIPTION
# Changelog:
- see commit

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
when there are no lessons in the course
<img width="1280" alt="Screenshot 2021-04-16 at 11 52 22 PM" src="https://user-images.githubusercontent.com/41737751/115051060-fa24b400-9f0e-11eb-963d-962b0a7e463b.png">

course progress is 0
<img width="1280" alt="Screenshot 2021-04-16 at 11 52 12 PM" src="https://user-images.githubusercontent.com/41737751/115051075-fdb83b00-9f0e-11eb-9765-52435350cf8f.png">
