### PR TITLE
Fix: show relevant set of achievements by user type

### DIFF
--- a/src/components/Common/Social/AchievementCard/index.js
+++ b/src/components/Common/Social/AchievementCard/index.js
@@ -1,7 +1,9 @@
 import { CloseOutlined } from '@ant-design/icons'
 import { Button, Empty } from 'antd'
+import { USER_TYPE_ENUM } from 'constants/constants'
 import medalImages from 'constants/hardcode/achievements'
-import { filter, isEmpty, isNil, map } from 'lodash'
+import { senseiAchievementTitles, studentAchievementTitles } from 'constants/information'
+import { filter, indexOf, isEmpty, isNil, map } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { getAllAchievements, getAllAchievementTypes } from 'services/user'
 
@@ -13,14 +15,25 @@ const AchievementCard = ({ user }) => {
   const [showSelectedAchievement, setShowSelectedAchievement] = useState(false)
 
   const getAchievementsSvc = async () => {
+    console.log('user is ', user)
     const achievementsRsp = await getAllAchievementTypes()
     if (achievementsRsp && !isNil(achievementsRsp.achievements)) {
-      setAllAchievements(achievementsRsp.achievements)
+      if (user.userType === USER_TYPE_ENUM.STUDENT) {
+        const studentAchievements = filter(achievementsRsp.achievements, a => {
+          return indexOf(studentAchievementTitles, a.title) >= 0
+        })
+        setAllAchievements(studentAchievements)
+      }
+      if (user.userType === USER_TYPE_ENUM.SENSEI) {
+        const senseiAchievements = filter(achievementsRsp.achievements, a => {
+          return indexOf(senseiAchievementTitles, a.title) >= 0
+        })
+        setAllAchievements(senseiAchievements)
+      }
     }
 
     if (user && !isNil(user.accountId)) {
       const userAchievementsRsp = await getAllAchievements(user.accountId)
-      console.log(userAchievementsRsp)
       if (userAchievementsRsp && !isNil(userAchievementsRsp.achievements)) {
         setUserAchievements(userAchievementsRsp.achievements)
       }

--- a/src/constants/information/index.js
+++ b/src/constants/information/index.js
@@ -1,3 +1,18 @@
+export const studentAchievementTitles = [
+  'Courses Purchased',
+  'Courses Completed',
+  'Mentorship Passes Purchased',
+  'Tasks Completed',
+  'Mentorships Completed',
+]
+
+export const senseiAchievementTitles = [
+  'Courses Published',
+  'Mentorship Listings Created',
+  'Students Mentored',
+  'Mentorships Completed',
+]
+
 export const industries = [
   {
     industryId: 1,


### PR DESCRIPTION
# Changelog:
- see commit log

## Checklist:

- [x] Merged latest develop
- [x] PR title makes sense

## Screenshots (where relevant):
**for a student**
![Screenshot 2021-04-17 at 12 54 58 AM](https://user-images.githubusercontent.com/41737751/115058356-c4d09400-9f17-11eb-8964-c6aadc2b8514.png)

**for a sensei**
![Screenshot 2021-04-17 at 12 54 03 AM](https://user-images.githubusercontent.com/41737751/115058372-c8641b00-9f17-11eb-9bc9-5935c38ea398.png)
