### PR TITLE
Aligned mobile menu items left

### DIFF
--- a/src/components/Public/PublicMenuBar/MenuLeft/index.js
+++ b/src/components/Public/PublicMenuBar/MenuLeft/index.js
@@ -219,19 +219,19 @@ const MenuLeft = ({
           >
             {generateMenuItems()}
           </Menu>
-          <div className="row justify-content-center mt-2">
+          <div className="row justify-content-start mt-2">
             <div className="col-6 text-center">
               <UserMenu />
             </div>
           </div>
-          <div className="row justify-content-center mt-2">
+          <div className="row justify-content-start mt-2">
             {user.authorized && user.userType !== USER_TYPE_ENUM.ADMIN && (
               <div className="col-6 text-center">
                 <ChatAction />
               </div>
             )}
           </div>
-          <div className="row justify-content-center mt-2">
+          <div className="row justify-content-start mt-2">
             {checkIfShowCart && (
               <div className="col-6 text-center">
                 <Cart />

--- a/src/components/Public/PublicMenuBar/MenuLeft/index.js
+++ b/src/components/Public/PublicMenuBar/MenuLeft/index.js
@@ -226,7 +226,12 @@ const MenuLeft = ({
           </div>
           <div className="row justify-content-start mt-2">
             {user.authorized && user.userType !== USER_TYPE_ENUM.ADMIN && (
-              <div className="col-6 text-center">
+              <div
+                className="col-6 text-center"
+                style={{
+                  paddingRight: isMobileView ? '30px' : '15px',
+                }}
+              >
                 <ChatAction />
               </div>
             )}


### PR DESCRIPTION
# Feature

Use Case: _Eg; A.1.7 View User Profile_
Feature ID : _Eg; 1_
Feature: _Eg; Sensei/Student Account Access_
Figma link for wireframe:

# Changelog:
- aligned mobile menu items left. Does not change desktop view

# Merge/Review Order

These other PRs should be merged or reviewed first

This PR blocks these other PRs

## Checklist:

- [ ] Merged latest develop
- [ ] PR title makes sense

## Screenshots (where relevant):
![image](https://user-images.githubusercontent.com/26864278/115069925-dd947600-9f26-11eb-987b-4d01a1a337b0.png)
